### PR TITLE
Consumers

### DIFF
--- a/Abstractions/Attributes/ConsumerGroupAttribute.cs
+++ b/Abstractions/Attributes/ConsumerGroupAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQContract.Attributes
+{
+    /// <summary>
+    /// Use this attribute to specify the GroupName that this Consumer will use when registering 
+    /// to supply to the underlying subscription.  This can be overriden in the registration call by passing 
+    /// a value for the group input.
+    /// </summary>
+    /// <param name="name">The name of the Group to identify this Consumer and it's underlying subscription</param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class ConsumerGroupAttribute(string name) : Attribute
+    {
+        /// <summary>
+        /// The name of the Group specified for this Consumer toi be part of
+        /// </summary>
+        public string Name => name;
+    }
+}

--- a/Abstractions/Attributes/ConsumerGroupAttribute.cs
+++ b/Abstractions/Attributes/ConsumerGroupAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.Attributes
+﻿namespace MQContract.Attributes
 {
     /// <summary>
     /// Use this attribute to specify the GroupName that this Consumer will use when registering 

--- a/Abstractions/Attributes/ConsumerIgnoreMessageHeaderAttribute.cs
+++ b/Abstractions/Attributes/ConsumerIgnoreMessageHeaderAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.Attributes
+﻿namespace MQContract.Attributes
 {
     /// <summary>
     /// Use this attribute to specify the if this consumer should ignore the message header as part of it's

--- a/Abstractions/Attributes/ConsumerIgnoreMessageHeaderAttribute.cs
+++ b/Abstractions/Attributes/ConsumerIgnoreMessageHeaderAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQContract.Attributes
+{
+    /// <summary>
+    /// Use this attribute to specify the if this consumer should ignore the message header as part of it's
+    /// underlying subscription.
+    /// </summary>
+    /// <param name="ignoreHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class ConsumerIgnoreMessageHeaderAttribute(bool ignoreHeader) : Attribute
+    {
+        /// <summary>
+        /// Indicates whether the underlying subscript should ignore the message header
+        /// </summary>
+        public bool IgnoreHeader => ignoreHeader;
+    }
+}

--- a/Abstractions/Attributes/ConsumerMessageChannelAttribute.cs
+++ b/Abstractions/Attributes/ConsumerMessageChannelAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.Attributes
+﻿namespace MQContract.Attributes
 {
     /// <summary>
     /// Use this attribute to specify the Channel name used for receiving messages by this consumer class.

--- a/Abstractions/Attributes/ConsumerMessageChannelAttribute.cs
+++ b/Abstractions/Attributes/ConsumerMessageChannelAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQContract.Attributes
+{
+    /// <summary>
+    /// Use this attribute to specify the Channel name used for receiving messages by this consumer class.
+    /// This would technically override the channel set by the Message class defined for the consumer,
+    /// and can be overriden by passing a channel value when registering the consumer.
+    /// </summary>
+    /// <param name="name">The name of the Channel to be used for receving messages to this consumer</param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class ConsumerMessageChannelAttribute(string name) : Attribute
+    {
+        /// <summary>
+        /// The name of the channel specified for this Consumer to listen to
+        /// </summary>
+        public string Name => name;
+    }
+}

--- a/Abstractions/Interfaces/Consumers/IBaseConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IBaseConsumer.cs
@@ -1,7 +1,14 @@
 ﻿namespace MQContract.Interfaces.Consumers
 {
+    /// <summary>
+    /// Represents the Base for all Consumer interfaces and contains the common method definition
+    /// </summary>
     public interface IBaseConsumer
     {
+        /// <summary>
+        /// Called when an error is received from within the underlying subscription that is using this Consumer
+        /// </summary>
+        /// <param name="error">The error that occured</param>
         void ErrorRecieved(Exception error);
     }
 }

--- a/Abstractions/Interfaces/Consumers/IBaseConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IBaseConsumer.cs
@@ -1,0 +1,7 @@
+﻿namespace MQContract.Interfaces.Consumers
+{
+    public interface IBaseConsumer
+    {
+        void ErrorRecieved(Exception error);
+    }
+}

--- a/Abstractions/Interfaces/Consumers/IPubSubAsyncConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IPubSubAsyncConsumer.cs
@@ -1,0 +1,8 @@
+﻿namespace MQContract.Interfaces.Consumers
+{
+    public interface IPubSubAsyncConsumer<T> : IBaseConsumer
+    {
+        ValueTask MessageReceivedAsync(IReceivedMessage<T> message);
+        
+    }
+}

--- a/Abstractions/Interfaces/Consumers/IPubSubAsyncConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IPubSubAsyncConsumer.cs
@@ -1,7 +1,16 @@
 ﻿namespace MQContract.Interfaces.Consumers
 {
-    public interface IPubSubAsyncConsumer<T> : IBaseConsumer
+    /// <summary>
+    /// Represents an Asynchronous PubSub Message Consumer to be registered to the ContractConnection
+    /// </summary>
+    /// <typeparam name="T">The type of Message that this Consumer will consume</typeparam>
+    public interface IPubSubAsyncConsumer<in T> : IBaseConsumer
     {
+        /// <summary>
+        /// Called when a message is recieved from the underlying subscription that is using this Consumer
+        /// </summary>
+        /// <param name="message">The message that was received</param>
+        /// <returns>A ValueTask for asynchronous operations</returns>
         ValueTask MessageReceivedAsync(IReceivedMessage<T> message);
         
     }

--- a/Abstractions/Interfaces/Consumers/IPubSubConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IPubSubConsumer.cs
@@ -1,0 +1,7 @@
+﻿namespace MQContract.Interfaces.Consumers
+{
+    public interface IPubSubConsumer<T> : IBaseConsumer
+    {
+        void MessageReceived(IReceivedMessage<T> message);
+    }
+}

--- a/Abstractions/Interfaces/Consumers/IPubSubConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IPubSubConsumer.cs
@@ -1,7 +1,15 @@
 ﻿namespace MQContract.Interfaces.Consumers
 {
-    public interface IPubSubConsumer<T> : IBaseConsumer
+    /// <summary>
+    /// Represents a PubSub Message Consumer to be registered to the ContractConnection
+    /// </summary>
+    /// <typeparam name="T">The type of Message that this Consumer will consume</typeparam>
+    public interface IPubSubConsumer<in T> : IBaseConsumer
     {
+        /// <summary>
+        /// Called when a message is recieved from the underlying subscription that is using this Consumer
+        /// </summary>
+        /// <param name="message">The message that was received</param>
         void MessageReceived(IReceivedMessage<T> message);
     }
 }

--- a/Abstractions/Interfaces/Consumers/IQueryResponseAsyncConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IQueryResponseAsyncConsumer.cs
@@ -2,8 +2,18 @@
 
 namespace MQContract.Interfaces.Consumers
 {
+    /// <summary>
+    /// Represents an Asynchronous QueryResponse Message Consumer to be registered to the ContractConnection
+    /// </summary>
+    /// <typeparam name="Q">The type of Message that is received and will be consumed</typeparam>
+    /// <typeparam name="R">The type of Message that is returned as a response</typeparam>
     public interface IQueryResponseAsyncConsumer<Q,R> : IBaseConsumer
     {
+        /// <summary>
+        /// Called when a message is received from the underlying subscript that is using this Consumer
+        /// </summary>
+        /// <param name="message">The message that was received</param>
+        /// <returns>The Response to the given Query Message</returns>
         ValueTask<QueryResponseMessage<R>> MessageReceivedAsync(IReceivedMessage<Q> message);
     }
 }

--- a/Abstractions/Interfaces/Consumers/IQueryResponseAsyncConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IQueryResponseAsyncConsumer.cs
@@ -1,0 +1,9 @@
+﻿using MQContract.Messages;
+
+namespace MQContract.Interfaces.Consumers
+{
+    public interface IQueryResponseAsyncConsumer<Q,R> : IBaseConsumer
+    {
+        ValueTask<QueryResponseMessage<R>> MessageReceivedAsync(IReceivedMessage<Q> message);
+    }
+}

--- a/Abstractions/Interfaces/Consumers/IQueryResponseConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IQueryResponseConsumer.cs
@@ -2,8 +2,17 @@
 
 namespace MQContract.Interfaces.Consumers
 {
+    /// <summary>
+    /// Represents a QueryResponse Message Consumer to be registered to the ContractConnection
+    /// </summary>
+    /// <typeparam name="Q">The type of Message that is received and will be consumed</typeparam>
+    /// <typeparam name="R">The type of Message that is returned as a response</typeparam>
     public interface IQueryResponseConsumer<Q,R> : IBaseConsumer
     {
+        /// <summary>
+        /// Called when a message is received from the underlying subscript that is using this Consumer
+        /// </summary>
+        /// <param name="message">The message that was received</param>
         QueryResponseMessage<R> MessageReceived(IReceivedMessage<Q> message);
     }
 }

--- a/Abstractions/Interfaces/Consumers/IQueryResponseConsumer.cs
+++ b/Abstractions/Interfaces/Consumers/IQueryResponseConsumer.cs
@@ -1,0 +1,9 @@
+﻿using MQContract.Messages;
+
+namespace MQContract.Interfaces.Consumers
+{
+    public interface IQueryResponseConsumer<Q,R> : IBaseConsumer
+    {
+        QueryResponseMessage<R> MessageReceived(IReceivedMessage<Q> message);
+    }
+}

--- a/Abstractions/Interfaces/IConsumerContractConnection.cs
+++ b/Abstractions/Interfaces/IConsumerContractConnection.cs
@@ -14,7 +14,7 @@ namespace MQContract.Interfaces
         /// <param name="assembly">Optional parameter to specify loading from a single assembly, if not supplied will load all from within the default LoadContext</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A boolean indicating success or failure</returns>
-        ValueTask<bool> AutoRegisterAllConsumersAsync(Assembly? assembly, CancellationToken cancellationToken = new CancellationToken());
+        ValueTask<bool> AutoRegisterAllConsumersAsync(Assembly? assembly=null, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to register a PubSubConsumer into the contract connection 
         /// </summary>

--- a/Abstractions/Interfaces/IConsumerContractConnection.cs
+++ b/Abstractions/Interfaces/IConsumerContractConnection.cs
@@ -1,0 +1,35 @@
+﻿using MQContract.Interfaces.Consumers;
+
+namespace MQContract.Interfaces
+{
+    public interface IConsumerContractConnection : IBaseContractConnection
+    {
+        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IPubSubConsumer<T>;
+        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IPubSubConsumer<T>;
+        ValueTask<bool> RegisterPubSubConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+
+        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IPubSubAsyncConsumer<T>;
+        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IPubSubAsyncConsumer<T>;
+        ValueTask<bool> RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+
+        ValueTask<bool> RegisterQueryResponseConsumerAsync<Q, R, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IQueryResponseConsumer<Q,R>;
+
+        ValueTask<bool> RegisterQueryResponseConsumerAsync<Q, R, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IQueryResponseConsumer<Q, R>;
+
+        ValueTask<bool> RegisterQueryResponseConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+
+        ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IQueryResponseAsyncConsumer<Q, R>;
+
+        ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+            where TConsumer : IQueryResponseAsyncConsumer<Q, R>;
+
+        ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+    }
+}

--- a/Abstractions/Interfaces/IConsumerContractConnection.cs
+++ b/Abstractions/Interfaces/IConsumerContractConnection.cs
@@ -1,35 +1,163 @@
 ﻿using MQContract.Interfaces.Consumers;
+using System.Reflection;
 
 namespace MQContract.Interfaces
 {
+    /// <summary>
+    /// This interface represents a portion of the Contract Connection, specifically the portion for registering all Consumer classes
+    /// </summary>
     public interface IConsumerContractConnection : IBaseContractConnection
     {
+        /// <summary>
+        /// Called to load all defined consumers found within the application, either within the supplied assembly or if null within the default LoadContext
+        /// </summary>
+        /// <param name="assembly">Optional parameter to specify loading from a single assembly, if not supplied will load all from within the default LoadContext</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
+        ValueTask<bool> AutoRegisterAllConsumersAsync(Assembly? assembly, CancellationToken cancellationToken = new CancellationToken());
+        /// <summary>
+        /// Called to register a PubSubConsumer into the contract connection 
+        /// </summary>
+        /// <typeparam name="T">The Message type</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IPubSubConsumer&lt;T&gt;</typeparam>
+        /// <param name="consumer">An instance of the consumer</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubConsumer<T>;
+        /// <summary>
+        /// Called to register a PubSubConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
+        /// </summary>
+        /// <typeparam name="T">The Message type</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IPubSubConsumer&lt;T&gt;</typeparam>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubConsumer<T>;
+        /// <summary>
+        /// Called to register a PubSubConsumer into the contract connection. 
+        /// </summary>
+        /// <param name="consumerType">The type instance to be constructed and registered into the system.  It must implement IPubSubConsumer&lt;T&gt;.</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
-
+        /// <summary>
+        /// Called to register a PubSubAsyncConsumer into the contract connection 
+        /// </summary>
+        /// <typeparam name="T">The Message type</typeparam>
+        /// <typeparam name="TConsumer">The type that implements PubSubAsyncConsumer&lt;T&gt;</typeparam>
+        /// <param name="consumer">An instance of the consumer</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubAsyncConsumer<T>;
+        /// <summary>
+        /// Called to register a PubSubAsyncConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
+        /// </summary>
+        /// <typeparam name="T">The Message type</typeparam>
+        /// <typeparam name="TConsumer">The type that implements PubSubAsyncConsumer&lt;T&gt;</typeparam>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubAsyncConsumer<T>;
+        /// <summary>
+        /// Called to register a PubSubAsyncConsumer into the contract connection. 
+        /// </summary>
+        /// <param name="consumerType">The type instance to be constructed and registered into the system.  It must implement IPubSubAsyncConsumer&lt;T&gt;.</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
-
+        /// <summary>
+        /// Called to register a QueryResponseConsumer into the contract connection 
+        /// </summary>
+        /// <typeparam name="Q">The type of message to listen for</typeparam>
+        /// <typeparam name="R">The type of message to respond with</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IQueryResponseConsumer&lt;Q,R&gt;</typeparam>
+        /// <param name="consumer">An instance of the consumer</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseConsumerAsync<Q, R, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IQueryResponseConsumer<Q,R>;
-
+        /// <summary>
+        /// Called to register a QueryResponseConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
+        /// </summary>
+        /// <typeparam name="Q">The type of message to listen for</typeparam>
+        /// <typeparam name="R">The type of message to respond with</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IQueryResponseConsumer&lt;Q,R&gt;</typeparam>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseConsumerAsync<Q, R, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IQueryResponseConsumer<Q, R>;
-
+        /// <summary>
+        /// Called to register a QueryResponseConsumer into the contract connection. 
+        /// </summary>
+        /// <param name="consumerType">The type instance to be constructed and registered into the system.  It must implement IQueryResponseConsumer&lt;Q,R&gt;.</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
-
+        /// <summary>
+        /// Called to register a QueryResponseAsyncConsumer into the contract connection 
+        /// </summary>
+        /// <typeparam name="Q">The type of message to listen for</typeparam>
+        /// <typeparam name="R">The type of message to respond with</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IQueryResponseAsyncConsumer&lt;Q,R&gt;</typeparam>
+        /// <param name="consumer">An instance of the consumer</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IQueryResponseAsyncConsumer<Q, R>;
-
+        /// <summary>
+        /// Called to register a QueryResponseAsyncConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
+        /// </summary>
+        /// <typeparam name="Q">The type of message to listen for</typeparam>
+        /// <typeparam name="R">The type of message to respond with</typeparam>
+        /// <typeparam name="TConsumer">The type that implements IQueryResponseAsyncConsumer&lt;Q,R&gt;</typeparam>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IQueryResponseAsyncConsumer<Q, R>;
-
+        /// <summary>
+        /// Called to register a QueryResponseAsyncConsumer into the contract connection. 
+        /// </summary>
+        /// <param name="consumerType">The type instance to be constructed and registered into the system.  It must implement IQueryResponseAsyncConsumer&lt;Q,R&gt;.</param>
+        /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
+        /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
+        /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns>A boolean indicating success or failure</returns>
         ValueTask<bool> RegisterQueryResponseAsyncConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
     }
 }

--- a/Abstractions/Interfaces/IContractConnection.cs
+++ b/Abstractions/Interfaces/IContractConnection.cs
@@ -5,7 +5,7 @@ namespace MQContract.Interfaces
     /// <summary>
     /// This interface represents the Core class for the MQContract system, IE the ContractConnection
     /// </summary>
-    public interface IContractConnection : IBaseContractConnection
+    public interface IContractConnection : IConsumerContractConnection
     {
         
         /// <summary>

--- a/Abstractions/Interfaces/IMappableContractConnection.cs
+++ b/Abstractions/Interfaces/IMappableContractConnection.cs
@@ -7,7 +7,7 @@ namespace MQContract.Interfaces
     /// A Mappable Contract Connection which supports mapping one or more Service Connections to a given message type, channel and or headers
     /// </summary>
     /// <typeparam name="CC">The underlying type that is being represented here which must be IBaseContractConnection, CC is used for method chaining.</typeparam>
-    public interface IMappableContractConnection<CC> : IBaseContractConnection
+    public interface IMappableContractConnection<CC> : IConsumerContractConnection
         where CC : IBaseContractConnection
     {
         /// <summary>

--- a/Abstractions/Interfaces/IMetricContractConnection.cs
+++ b/Abstractions/Interfaces/IMetricContractConnection.cs
@@ -7,7 +7,7 @@ namespace MQContract.Interfaces
     /// Houses the metric pieces for a given contract connection
     /// </summary>
     /// <typeparam name="CC">The underlying type that is being represented here which must be IBaseContractConnection, CC is used for method chaining.</typeparam>
-    public interface IMetricContractConnection<CC> : IBaseContractConnection
+    public interface IMetricContractConnection<CC> : IConsumerContractConnection
         where CC : IBaseContractConnection
     {
         /// <summary>

--- a/Abstractions/Readme.md
+++ b/Abstractions/Readme.md
@@ -8,12 +8,23 @@
   - [Error](#P-MQContract-Messages-ChildTransmissionResult-Error 'MQContract.Messages.ChildTransmissionResult.Error')
   - [IsError](#P-MQContract-Messages-ChildTransmissionResult-IsError 'MQContract.Messages.ChildTransmissionResult.IsError')
   - [ServiceName](#P-MQContract-Messages-ChildTransmissionResult-ServiceName 'MQContract.Messages.ChildTransmissionResult.ServiceName')
+- [ConsumerGroupAttribute](#T-MQContract-Attributes-ConsumerGroupAttribute 'MQContract.Attributes.ConsumerGroupAttribute')
+  - [#ctor(name)](#M-MQContract-Attributes-ConsumerGroupAttribute-#ctor-System-String- 'MQContract.Attributes.ConsumerGroupAttribute.#ctor(System.String)')
+  - [Name](#P-MQContract-Attributes-ConsumerGroupAttribute-Name 'MQContract.Attributes.ConsumerGroupAttribute.Name')
+- [ConsumerIgnoreMessageHeaderAttribute](#T-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute 'MQContract.Attributes.ConsumerIgnoreMessageHeaderAttribute')
+  - [#ctor(ignoreHeader)](#M-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute-#ctor-System-Boolean- 'MQContract.Attributes.ConsumerIgnoreMessageHeaderAttribute.#ctor(System.Boolean)')
+  - [IgnoreHeader](#P-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute-IgnoreHeader 'MQContract.Attributes.ConsumerIgnoreMessageHeaderAttribute.IgnoreHeader')
+- [ConsumerMessageChannelAttribute](#T-MQContract-Attributes-ConsumerMessageChannelAttribute 'MQContract.Attributes.ConsumerMessageChannelAttribute')
+  - [#ctor(name)](#M-MQContract-Attributes-ConsumerMessageChannelAttribute-#ctor-System-String- 'MQContract.Attributes.ConsumerMessageChannelAttribute.#ctor(System.String)')
+  - [Name](#P-MQContract-Attributes-ConsumerMessageChannelAttribute-Name 'MQContract.Attributes.ConsumerMessageChannelAttribute.Name')
 - [IAfterDecodeMiddleware](#T-MQContract-Interfaces-Middleware-IAfterDecodeMiddleware 'MQContract.Interfaces.Middleware.IAfterDecodeMiddleware')
   - [AfterMessageDecodeAsync\`\`1(context,message,ID,messageHeader,receivedTimestamp,processedTimeStamp)](#M-MQContract-Interfaces-Middleware-IAfterDecodeMiddleware-AfterMessageDecodeAsync``1-MQContract-Interfaces-Middleware-IContext,``0,System-String,MQContract-Messages-MessageHeader,System-DateTime,System-DateTime- 'MQContract.Interfaces.Middleware.IAfterDecodeMiddleware.AfterMessageDecodeAsync``1(MQContract.Interfaces.Middleware.IContext,``0,System.String,MQContract.Messages.MessageHeader,System.DateTime,System.DateTime)')
 - [IAfterDecodeSpecificTypeMiddleware\`1](#T-MQContract-Interfaces-Middleware-IAfterDecodeSpecificTypeMiddleware`1 'MQContract.Interfaces.Middleware.IAfterDecodeSpecificTypeMiddleware`1')
   - [AfterMessageDecodeAsync(context,message,ID,messageHeader,receivedTimestamp,processedTimeStamp)](#M-MQContract-Interfaces-Middleware-IAfterDecodeSpecificTypeMiddleware`1-AfterMessageDecodeAsync-MQContract-Interfaces-Middleware-IContext,`0,System-String,MQContract-Messages-MessageHeader,System-DateTime,System-DateTime- 'MQContract.Interfaces.Middleware.IAfterDecodeSpecificTypeMiddleware`1.AfterMessageDecodeAsync(MQContract.Interfaces.Middleware.IContext,`0,System.String,MQContract.Messages.MessageHeader,System.DateTime,System.DateTime)')
 - [IAfterEncodeMiddleware](#T-MQContract-Interfaces-Middleware-IAfterEncodeMiddleware 'MQContract.Interfaces.Middleware.IAfterEncodeMiddleware')
   - [AfterMessageEncodeAsync(messageType,context,message)](#M-MQContract-Interfaces-Middleware-IAfterEncodeMiddleware-AfterMessageEncodeAsync-System-Type,MQContract-Interfaces-Middleware-IContext,MQContract-Messages-ServiceMessage- 'MQContract.Interfaces.Middleware.IAfterEncodeMiddleware.AfterMessageEncodeAsync(System.Type,MQContract.Interfaces.Middleware.IContext,MQContract.Messages.ServiceMessage)')
+- [IBaseConsumer](#T-MQContract-Interfaces-Consumers-IBaseConsumer 'MQContract.Interfaces.Consumers.IBaseConsumer')
+  - [ErrorRecieved(error)](#M-MQContract-Interfaces-Consumers-IBaseConsumer-ErrorRecieved-System-Exception- 'MQContract.Interfaces.Consumers.IBaseConsumer.ErrorRecieved(System.Exception)')
 - [IBaseContractConnection](#T-MQContract-Interfaces-IBaseContractConnection 'MQContract.Interfaces.IBaseContractConnection')
   - [CloseAsync()](#M-MQContract-Interfaces-IBaseContractConnection-CloseAsync 'MQContract.Interfaces.IBaseContractConnection.CloseAsync')
   - [SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeAsync``1(System.Func{MQContract.Interfaces.IReceivedMessage{``0},System.Threading.Tasks.ValueTask},System.Action{System.Exception},System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
@@ -28,6 +39,20 @@
   - [BeforeMessageEncodeAsync(context,message,channel,messageHeader)](#M-MQContract-Interfaces-Middleware-IBeforeEncodeSpecificTypeMiddleware`1-BeforeMessageEncodeAsync-MQContract-Interfaces-Middleware-IContext,`0,System-String,MQContract-Messages-MessageHeader- 'MQContract.Interfaces.Middleware.IBeforeEncodeSpecificTypeMiddleware`1.BeforeMessageEncodeAsync(MQContract.Interfaces.Middleware.IContext,`0,System.String,MQContract.Messages.MessageHeader)')
 - [IBulkPublishableMessageServiceConnection](#T-MQContract-Interfaces-Service-IBulkPublishableMessageServiceConnection 'MQContract.Interfaces.Service.IBulkPublishableMessageServiceConnection')
   - [BulkPublishAsync(messages,cancellationToken)](#M-MQContract-Interfaces-Service-IBulkPublishableMessageServiceConnection-BulkPublishAsync-System-Collections-Generic-IEnumerable{MQContract-Messages-ServiceMessage},System-Threading-CancellationToken- 'MQContract.Interfaces.Service.IBulkPublishableMessageServiceConnection.BulkPublishAsync(System.Collections.Generic.IEnumerable{MQContract.Messages.ServiceMessage},System.Threading.CancellationToken)')
+- [IConsumerContractConnection](#T-MQContract-Interfaces-IConsumerContractConnection 'MQContract.Interfaces.IConsumerContractConnection')
+  - [AutoRegisterAllConsumersAsync(assembly,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-AutoRegisterAllConsumersAsync-System-Reflection-Assembly,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.AutoRegisterAllConsumersAsync(System.Reflection.Assembly,System.Threading.CancellationToken)')
+  - [RegisterPubSubAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(``1,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(``1,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseAsyncConsumerAsync\`\`3(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-``2,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync``3(``2,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseAsyncConsumerAsync\`\`3(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync``3(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseConsumerAsync\`\`3(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync``3-``2,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseConsumerAsync``3(``2,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterQueryResponseConsumerAsync\`\`3(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync``3-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseConsumerAsync``3(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
 - [IContext](#T-MQContract-Interfaces-Middleware-IContext 'MQContract.Interfaces.Middleware.IContext')
   - [Item](#P-MQContract-Interfaces-Middleware-IContext-Item-System-String- 'MQContract.Interfaces.Middleware.IContext.Item(System.String)')
 - [IContractConnection](#T-MQContract-Interfaces-IContractConnection 'MQContract.Interfaces.IContractConnection')
@@ -98,6 +123,14 @@
   - [RegisterServiceConnection(serviceConnectionName,messageServiceConnection)](#M-MQContract-Interfaces-IMultiServiceContractConnection-RegisterServiceConnection-System-String,MQContract-Interfaces-Service-IMessageServiceConnection- 'MQContract.Interfaces.IMultiServiceContractConnection.RegisterServiceConnection(System.String,MQContract.Interfaces.Service.IMessageServiceConnection)')
 - [IPingableMessageServiceConnection](#T-MQContract-Interfaces-Service-IPingableMessageServiceConnection 'MQContract.Interfaces.Service.IPingableMessageServiceConnection')
   - [PingAsync()](#M-MQContract-Interfaces-Service-IPingableMessageServiceConnection-PingAsync 'MQContract.Interfaces.Service.IPingableMessageServiceConnection.PingAsync')
+- [IPubSubAsyncConsumer\`1](#T-MQContract-Interfaces-Consumers-IPubSubAsyncConsumer`1 'MQContract.Interfaces.Consumers.IPubSubAsyncConsumer`1')
+  - [MessageReceivedAsync(message)](#M-MQContract-Interfaces-Consumers-IPubSubAsyncConsumer`1-MessageReceivedAsync-MQContract-Interfaces-IReceivedMessage{`0}- 'MQContract.Interfaces.Consumers.IPubSubAsyncConsumer`1.MessageReceivedAsync(MQContract.Interfaces.IReceivedMessage{`0})')
+- [IPubSubConsumer\`1](#T-MQContract-Interfaces-Consumers-IPubSubConsumer`1 'MQContract.Interfaces.Consumers.IPubSubConsumer`1')
+  - [MessageReceived(message)](#M-MQContract-Interfaces-Consumers-IPubSubConsumer`1-MessageReceived-MQContract-Interfaces-IReceivedMessage{`0}- 'MQContract.Interfaces.Consumers.IPubSubConsumer`1.MessageReceived(MQContract.Interfaces.IReceivedMessage{`0})')
+- [IQueryResponseAsyncConsumer\`2](#T-MQContract-Interfaces-Consumers-IQueryResponseAsyncConsumer`2 'MQContract.Interfaces.Consumers.IQueryResponseAsyncConsumer`2')
+  - [MessageReceivedAsync(message)](#M-MQContract-Interfaces-Consumers-IQueryResponseAsyncConsumer`2-MessageReceivedAsync-MQContract-Interfaces-IReceivedMessage{`0}- 'MQContract.Interfaces.Consumers.IQueryResponseAsyncConsumer`2.MessageReceivedAsync(MQContract.Interfaces.IReceivedMessage{`0})')
+- [IQueryResponseConsumer\`2](#T-MQContract-Interfaces-Consumers-IQueryResponseConsumer`2 'MQContract.Interfaces.Consumers.IQueryResponseConsumer`2')
+  - [MessageReceived(message)](#M-MQContract-Interfaces-Consumers-IQueryResponseConsumer`2-MessageReceived-MQContract-Interfaces-IReceivedMessage{`0}- 'MQContract.Interfaces.Consumers.IQueryResponseConsumer`2.MessageReceived(MQContract.Interfaces.IReceivedMessage{`0})')
 - [IQueryResponseMessageServiceConnection](#T-MQContract-Interfaces-Service-IQueryResponseMessageServiceConnection 'MQContract.Interfaces.Service.IQueryResponseMessageServiceConnection')
   - [QueryAsync(message,timeout,cancellationToken)](#M-MQContract-Interfaces-Service-IQueryResponseMessageServiceConnection-QueryAsync-MQContract-Messages-ServiceMessage,System-TimeSpan,System-Threading-CancellationToken- 'MQContract.Interfaces.Service.IQueryResponseMessageServiceConnection.QueryAsync(MQContract.Messages.ServiceMessage,System.TimeSpan,System.Threading.CancellationToken)')
 - [IQueryableMessageServiceConnection](#T-MQContract-Interfaces-Service-IQueryableMessageServiceConnection 'MQContract.Interfaces.Service.IQueryableMessageServiceConnection')
@@ -235,6 +268,127 @@ Flag to indicate if the result is an error
 
 The unique name of the underlying service that was used to transmit
 
+<a name='T-MQContract-Attributes-ConsumerGroupAttribute'></a>
+## ConsumerGroupAttribute `type`
+
+##### Namespace
+
+MQContract.Attributes
+
+##### Summary
+
+Use this attribute to specify the GroupName that this Consumer will use when registering 
+to supply to the underlying subscription.  This can be overriden in the registration call by passing 
+a value for the group input.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [T:MQContract.Attributes.ConsumerGroupAttribute](#T-T-MQContract-Attributes-ConsumerGroupAttribute 'T:MQContract.Attributes.ConsumerGroupAttribute') | The name of the Group to identify this Consumer and it's underlying subscription |
+
+<a name='M-MQContract-Attributes-ConsumerGroupAttribute-#ctor-System-String-'></a>
+### #ctor(name) `constructor`
+
+##### Summary
+
+Use this attribute to specify the GroupName that this Consumer will use when registering 
+to supply to the underlying subscription.  This can be overriden in the registration call by passing 
+a value for the group input.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the Group to identify this Consumer and it's underlying subscription |
+
+<a name='P-MQContract-Attributes-ConsumerGroupAttribute-Name'></a>
+### Name `property`
+
+##### Summary
+
+The name of the Group specified for this Consumer toi be part of
+
+<a name='T-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute'></a>
+## ConsumerIgnoreMessageHeaderAttribute `type`
+
+##### Namespace
+
+MQContract.Attributes
+
+##### Summary
+
+Use this attribute to specify the if this consumer should ignore the message header as part of it's
+underlying subscription.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| ignoreHeader | [T:MQContract.Attributes.ConsumerIgnoreMessageHeaderAttribute](#T-T-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute 'T:MQContract.Attributes.ConsumerIgnoreMessageHeaderAttribute') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+
+<a name='M-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute-#ctor-System-Boolean-'></a>
+### #ctor(ignoreHeader) `constructor`
+
+##### Summary
+
+Use this attribute to specify the if this consumer should ignore the message header as part of it's
+underlying subscription.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| ignoreHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+
+<a name='P-MQContract-Attributes-ConsumerIgnoreMessageHeaderAttribute-IgnoreHeader'></a>
+### IgnoreHeader `property`
+
+##### Summary
+
+Indicates whether the underlying subscript should ignore the message header
+
+<a name='T-MQContract-Attributes-ConsumerMessageChannelAttribute'></a>
+## ConsumerMessageChannelAttribute `type`
+
+##### Namespace
+
+MQContract.Attributes
+
+##### Summary
+
+Use this attribute to specify the Channel name used for receiving messages by this consumer class.
+This would technically override the channel set by the Message class defined for the consumer,
+and can be overriden by passing a channel value when registering the consumer.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [T:MQContract.Attributes.ConsumerMessageChannelAttribute](#T-T-MQContract-Attributes-ConsumerMessageChannelAttribute 'T:MQContract.Attributes.ConsumerMessageChannelAttribute') | The name of the Channel to be used for receving messages to this consumer |
+
+<a name='M-MQContract-Attributes-ConsumerMessageChannelAttribute-#ctor-System-String-'></a>
+### #ctor(name) `constructor`
+
+##### Summary
+
+Use this attribute to specify the Channel name used for receiving messages by this consumer class.
+This would technically override the channel set by the Message class defined for the consumer,
+and can be overriden by passing a channel value when registering the consumer.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the Channel to be used for receving messages to this consumer |
+
+<a name='P-MQContract-Attributes-ConsumerMessageChannelAttribute-Name'></a>
+### Name `property`
+
+##### Summary
+
+The name of the channel specified for this Consumer to listen to
+
 <a name='T-MQContract-Interfaces-Middleware-IAfterDecodeMiddleware'></a>
 ## IAfterDecodeMiddleware `type`
 
@@ -336,6 +490,30 @@ The message to allow for changes if desired
 | messageType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') | The class of the message type that was encoded |
 | context | [MQContract.Interfaces.Middleware.IContext](#T-MQContract-Interfaces-Middleware-IContext 'MQContract.Interfaces.Middleware.IContext') | A shared context that exists from the start of this encode process instance |
 | message | [MQContract.Messages.ServiceMessage](#T-MQContract-Messages-ServiceMessage 'MQContract.Messages.ServiceMessage') | The resulting encoded message |
+
+<a name='T-MQContract-Interfaces-Consumers-IBaseConsumer'></a>
+## IBaseConsumer `type`
+
+##### Namespace
+
+MQContract.Interfaces.Consumers
+
+##### Summary
+
+Represents the Base for all Consumer interfaces and contains the common method definition
+
+<a name='M-MQContract-Interfaces-Consumers-IBaseConsumer-ErrorRecieved-System-Exception-'></a>
+### ErrorRecieved(error) `method`
+
+##### Summary
+
+Called when an error is received from within the underlying subscription that is using this Consumer
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| error | [System.Exception](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Exception 'System.Exception') | The error that occured |
 
 <a name='T-MQContract-Interfaces-IBaseContractConnection'></a>
 ## IBaseContractConnection `type`
@@ -606,6 +784,343 @@ A transmission result instance indicating the result for each message
 | ---- | ---- | ----------- |
 | messages | [System.Collections.Generic.IEnumerable{MQContract.Messages.ServiceMessage}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{MQContract.Messages.ServiceMessage}') | The message to publish |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='T-MQContract-Interfaces-IConsumerContractConnection'></a>
+## IConsumerContractConnection `type`
+
+##### Namespace
+
+MQContract.Interfaces
+
+##### Summary
+
+This interface represents a portion of the Contract Connection, specifically the portion for registering all Consumer classes
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-AutoRegisterAllConsumersAsync-System-Reflection-Assembly,System-Threading-CancellationToken-'></a>
+### AutoRegisterAllConsumersAsync(assembly,cancellationToken) `method`
+
+##### Summary
+
+Called to load all defined consumers found within the application, either within the supplied assembly or if null within the default LoadContext
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| assembly | [System.Reflection.Assembly](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Reflection.Assembly 'System.Reflection.Assembly') | Optional parameter to specify loading from a single assembly, if not supplied will load all from within the default LoadContext |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubAsyncConsumer into the contract connection.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumerType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') | The type instance to be constructed and registered into the system.  It must implement IPubSubAsyncConsumer<T>. |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubAsyncConsumer into the contract connection
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumer | [\`\`1](#T-``1 '``1') | An instance of the consumer |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The Message type |
+| TConsumer | The type that implements PubSubAsyncConsumer<T> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubAsyncConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The Message type |
+| TConsumer | The type that implements PubSubAsyncConsumer<T> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubConsumer into the contract connection.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumerType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') | The type instance to be constructed and registered into the system.  It must implement IPubSubConsumer<T>. |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubConsumer into the contract connection
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumer | [\`\`1](#T-``1 '``1') | An instance of the consumer |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The Message type |
+| TConsumer | The type that implements IPubSubConsumer<T> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a PubSubConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The Message type |
+| TConsumer | The type that implements IPubSubConsumer<T> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseAsyncConsumer into the contract connection.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumerType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') | The type instance to be constructed and registered into the system.  It must implement IQueryResponseAsyncConsumer<Q,R>. |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-``2,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseAsyncConsumerAsync\`\`3(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseAsyncConsumer into the contract connection
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumer | [\`\`2](#T-``2 '``2') | An instance of the consumer |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of message to listen for |
+| R | The type of message to respond with |
+| TConsumer | The type that implements IQueryResponseAsyncConsumer<Q,R> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseAsyncConsumerAsync\`\`3(channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseAsyncConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of message to listen for |
+| R | The type of message to respond with |
+| TConsumer | The type that implements IQueryResponseAsyncConsumer<Q,R> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseConsumer into the contract connection.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumerType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') | The type instance to be constructed and registered into the system.  It must implement IQueryResponseConsumer<Q,R>. |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync``3-``2,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseConsumerAsync\`\`3(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseConsumer into the contract connection
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| consumer | [\`\`2](#T-``2 '``2') | An instance of the consumer |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of message to listen for |
+| R | The type of message to respond with |
+| TConsumer | The type that implements IQueryResponseConsumer<Q,R> |
+
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseConsumerAsync``3-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
+### RegisterQueryResponseConsumerAsync\`\`3(channel,group,ignoreMessageHeader,cancellationToken) `method`
+
+##### Summary
+
+Called to register a QueryResponseConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it.
+
+##### Returns
+
+A boolean indicating success or failure
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
+| group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
+| ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of message to listen for |
+| R | The type of message to respond with |
+| TConsumer | The type that implements IQueryResponseConsumer<Q,R> |
 
 <a name='T-MQContract-Interfaces-Middleware-IContext'></a>
 ## IContext `type`
@@ -1773,6 +2288,136 @@ A Ping Result
 ##### Parameters
 
 This method has no parameters.
+
+<a name='T-MQContract-Interfaces-Consumers-IPubSubAsyncConsumer`1'></a>
+## IPubSubAsyncConsumer\`1 `type`
+
+##### Namespace
+
+MQContract.Interfaces.Consumers
+
+##### Summary
+
+Represents an Asynchronous PubSub Message Consumer to be registered to the ContractConnection
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The type of Message that this Consumer will consume |
+
+<a name='M-MQContract-Interfaces-Consumers-IPubSubAsyncConsumer`1-MessageReceivedAsync-MQContract-Interfaces-IReceivedMessage{`0}-'></a>
+### MessageReceivedAsync(message) `method`
+
+##### Summary
+
+Called when a message is recieved from the underlying subscription that is using this Consumer
+
+##### Returns
+
+A ValueTask for asynchronous operations
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| message | [MQContract.Interfaces.IReceivedMessage{\`0}](#T-MQContract-Interfaces-IReceivedMessage{`0} 'MQContract.Interfaces.IReceivedMessage{`0}') | The message that was received |
+
+<a name='T-MQContract-Interfaces-Consumers-IPubSubConsumer`1'></a>
+## IPubSubConsumer\`1 `type`
+
+##### Namespace
+
+MQContract.Interfaces.Consumers
+
+##### Summary
+
+Represents a PubSub Message Consumer to be registered to the ContractConnection
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The type of Message that this Consumer will consume |
+
+<a name='M-MQContract-Interfaces-Consumers-IPubSubConsumer`1-MessageReceived-MQContract-Interfaces-IReceivedMessage{`0}-'></a>
+### MessageReceived(message) `method`
+
+##### Summary
+
+Called when a message is recieved from the underlying subscription that is using this Consumer
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| message | [MQContract.Interfaces.IReceivedMessage{\`0}](#T-MQContract-Interfaces-IReceivedMessage{`0} 'MQContract.Interfaces.IReceivedMessage{`0}') | The message that was received |
+
+<a name='T-MQContract-Interfaces-Consumers-IQueryResponseAsyncConsumer`2'></a>
+## IQueryResponseAsyncConsumer\`2 `type`
+
+##### Namespace
+
+MQContract.Interfaces.Consumers
+
+##### Summary
+
+Represents an Asynchronous QueryResponse Message Consumer to be registered to the ContractConnection
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of Message that is received and will be consumed |
+| R | The type of Message that is returned as a response |
+
+<a name='M-MQContract-Interfaces-Consumers-IQueryResponseAsyncConsumer`2-MessageReceivedAsync-MQContract-Interfaces-IReceivedMessage{`0}-'></a>
+### MessageReceivedAsync(message) `method`
+
+##### Summary
+
+Called when a message is received from the underlying subscript that is using this Consumer
+
+##### Returns
+
+The Response to the given Query Message
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| message | [MQContract.Interfaces.IReceivedMessage{\`0}](#T-MQContract-Interfaces-IReceivedMessage{`0} 'MQContract.Interfaces.IReceivedMessage{`0}') | The message that was received |
+
+<a name='T-MQContract-Interfaces-Consumers-IQueryResponseConsumer`2'></a>
+## IQueryResponseConsumer\`2 `type`
+
+##### Namespace
+
+MQContract.Interfaces.Consumers
+
+##### Summary
+
+Represents a QueryResponse Message Consumer to be registered to the ContractConnection
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| Q | The type of Message that is received and will be consumed |
+| R | The type of Message that is returned as a response |
+
+<a name='M-MQContract-Interfaces-Consumers-IQueryResponseConsumer`2-MessageReceived-MQContract-Interfaces-IReceivedMessage{`0}-'></a>
+### MessageReceived(message) `method`
+
+##### Summary
+
+Called when a message is received from the underlying subscript that is using this Consumer
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| message | [MQContract.Interfaces.IReceivedMessage{\`0}](#T-MQContract-Interfaces-IReceivedMessage{`0} 'MQContract.Interfaces.IReceivedMessage{`0}') | The message that was received |
 
 <a name='T-MQContract-Interfaces-Service-IQueryResponseMessageServiceConnection'></a>
 ## IQueryResponseMessageServiceConnection `type`

--- a/AutomatedTesting/AutomatedTesting.csproj
+++ b/AutomatedTesting/AutomatedTesting.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
 	  <PackageReference Include="Moq" Version="4.20.72" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-	  <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+	  <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+	  <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
 	  <PackageReference Include="coverlet.collector" Version="6.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AutomatedTesting/ConnectionTests/Consumers/AutoConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/AutoConsumerTests.cs
@@ -1,0 +1,284 @@
+﻿using AutomatedTesting.Messages;
+using Moq;
+using MQContract.Attributes;
+using MQContract.Interfaces.Service;
+using MQContract;
+using System.Reflection;
+using AutomatedTesting.Consumers;
+
+namespace AutomatedTesting.ConnectionTests.Consumers
+{
+    [TestClass]
+    public class AutoConsumerTests
+    {
+        [TestMethod]
+        public async ValueTask CheckLoadConsumersWithAssembly()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x=>x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);  
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync(GetType().Assembly);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.DisposeAsync();
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), 
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name, 
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Exactly(4));
+            #endregion
+        }
+
+        [TestMethod]
+        public async ValueTask CheckLoadConsumersWithoutAssembly()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync();
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.DisposeAsync();
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Exactly(4));
+            #endregion
+        }
+
+        [TestMethod]
+        public async ValueTask CheckLoadConsumerWithFailureToCreateSubscriptionForPubSubConsumer()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IServiceSubscription?)null);
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync(GetType().Assembly);
+            #endregion
+
+            #region Assert
+            Assert.IsFalse(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod]
+        public async ValueTask CheckLoadConsumerWithFailureToCreateSubscriptionForPubSubAsyncConsumer()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IServiceSubscription?)null);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync(GetType().Assembly);
+            #endregion
+
+            #region Assert
+            Assert.IsFalse(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod]
+        public async ValueTask CheckLoadConsumerWithFailureToCreateSubscriptionForQueryResponseConsumer()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IServiceSubscription?)null);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync(GetType().Assembly);
+            #endregion
+
+            #region Assert
+            Assert.IsFalse(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod]
+        public async ValueTask CheckLoadConsumerWithFailureToCreateSubscriptionForQueryResponseAsyncConsumer()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                    null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IServiceSubscription?)null);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.AutoRegisterAllConsumersAsync(GetType().Assembly);
+            #endregion
+
+            #region Assert
+            Assert.IsFalse(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                    typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
+                    It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+    }
+}

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
@@ -209,8 +209,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
 
             #region Verify
             serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
-                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
-                mappedGroup,
+                mappedChannel??typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                mappedGroup??typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
                 It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }
@@ -287,8 +287,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
 
             #region Verify
             serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
-                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
-                mappedGroup,
+                mappedChannel??typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                mappedGroup??typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
                 It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
@@ -1,0 +1,325 @@
+﻿using AutomatedTesting.Messages;
+using Moq;
+using MQContract.Attributes;
+using MQContract.Interfaces.Service;
+using MQContract.Interfaces;
+using MQContract;
+using System.Diagnostics;
+using MQContract.Interfaces.Consumers;
+using System.Reflection;
+using AutomatedTesting.Consumers;
+
+namespace AutomatedTesting.ConnectionTests.Consumers
+{
+    [TestClass]
+    public class PubSubAsyncConsumerTests
+    {
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsAndSuppliedInstance()
+        {
+            #region Arrange
+            var acknowledged = false;
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var messages = new List<IReceivedMessage<BasicMessage>>();
+            var exceptions = new List<Exception>();
+
+            var mockConsumer = new Mock<IPubSubAsyncConsumer<BasicMessage>>();
+            mockConsumer.Setup(x => x.ErrorRecieved(Capture.In(exceptions)));
+            mockConsumer.Setup(x => x.MessageReceivedAsync(Capture.In(messages)))
+                .Returns(ValueTask.CompletedTask);
+
+            var message = new BasicMessage("TestSubscribeAsyncWithNoExtendedAspects");
+            var exception = new NullReferenceException("TestSubscribeAsyncWithNoExtendedAspects");
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync<BasicMessage, IPubSubAsyncConsumer<BasicMessage>>(mockConsumer.Object);
+            var result = await contractConnection.PublishAsync<BasicMessage>(message);
+            foreach (var act in errorActions)
+                act(exception);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(1, exceptions.Count);
+            Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+            Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+            Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+            Assert.AreEqual(message, messages[0].Message);
+            Assert.AreEqual(exception, exceptions[0]);
+            Assert.IsTrue(acknowledged);
+            Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x=>x.EndAsync(), Times.Once);    
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel",null)]
+        [DataRow(null, "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsAndSuppliedInstanceWithParameters(string? channel,string? group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var mockConsumer = new Mock<IPubSubAsyncConsumer<BasicMessage>>();
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync<BasicMessage, IPubSubAsyncConsumer<BasicMessage>>(mockConsumer.Object,channel:mappedChannel,group:mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup, 
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsWithoutInstance()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync<BasicMessage, BasicMessageAsyncConsumer>();
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
+            Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsWithoutInstanceWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync<BasicMessage, BasicMessageAsyncConsumer>(channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync(typeof(BasicMessageAsyncConsumer));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
+            Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingTypeWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync(typeof(BasicMessageAsyncConsumer),channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckRegistrationUsingTypeWithInvalidType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var error = await Assert.ThrowsAsync<InvalidConsumerType>(async()=>await contractConnection.RegisterPubSubAsyncConsumerAsync(typeof(PubSubAsyncConsumerTests)));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(error);
+            Assert.AreEqual($"Unable to register consumer of Type {typeof(PubSubAsyncConsumerTests).FullName} because it does not implement the interface {typeof(IPubSubAsyncConsumer<>).Name}",
+                error.Message);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            #endregion
+        }
+    }
+}

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
@@ -1,0 +1,324 @@
+﻿using AutomatedTesting.Messages;
+using Moq;
+using MQContract.Attributes;
+using MQContract.Interfaces.Service;
+using MQContract.Interfaces;
+using MQContract;
+using System.Diagnostics;
+using MQContract.Interfaces.Consumers;
+using System.Reflection;
+using AutomatedTesting.Consumers;
+
+namespace AutomatedTesting.ConnectionTests.Consumers
+{
+    [TestClass]
+    public class PubSubConsumerTests
+    {
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsAndSuppliedInstance()
+        {
+            #region Arrange
+            var acknowledged = false;
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var messages = new List<IReceivedMessage<BasicMessage>>();
+            var exceptions = new List<Exception>();
+
+            var mockConsumer = new Mock<IPubSubConsumer<BasicMessage>>();
+            mockConsumer.Setup(x => x.ErrorRecieved(Capture.In(exceptions)));
+            mockConsumer.Setup(x => x.MessageReceived(Capture.In(messages)));
+
+            var message = new BasicMessage("TestSubscribeAsyncWithNoExtendedAspects");
+            var exception = new NullReferenceException("TestSubscribeAsyncWithNoExtendedAspects");
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync<BasicMessage, IPubSubConsumer<BasicMessage>>(mockConsumer.Object);
+            var result = await contractConnection.PublishAsync<BasicMessage>(message);
+            foreach (var act in errorActions)
+                act(exception);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(1, exceptions.Count);
+            Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+            Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+            Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+            Assert.AreEqual(message, messages[0].Message);
+            Assert.AreEqual(exception, exceptions[0]);
+            Assert.IsTrue(acknowledged);
+            Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x=>x.EndAsync(), Times.Once);    
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel",null)]
+        [DataRow(null, "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsAndSuppliedInstanceWithParameters(string? channel,string? group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var mockConsumer = new Mock<IPubSubConsumer<BasicMessage>>();
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync<BasicMessage, IPubSubConsumer<BasicMessage>>(mockConsumer.Object,channel:mappedChannel,group:mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup, 
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsWithoutInstance()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync<BasicMessage, BasicMessageConsumer>();
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsWithoutInstanceWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync<BasicMessage, BasicMessageConsumer>(channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync(typeof(BasicMessageConsumer));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingTypeWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync(typeof(BasicMessageConsumer),channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckRegistrationUsingTypeWithInvalidType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var error = await Assert.ThrowsAsync<InvalidConsumerType>(async()=>await contractConnection.RegisterPubSubConsumerAsync(typeof(PubSubConsumerTests)));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(error);
+            Assert.AreEqual($"Unable to register consumer of Type {typeof(PubSubConsumerTests).FullName} because it does not implement the interface {typeof(IPubSubConsumer<>).Name}",
+                error.Message);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            #endregion
+        }
+    }
+}

--- a/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
@@ -214,8 +214,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
 
             #region Verify
             serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
-                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
-                mappedGroup,
+                mappedChannel??typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                mappedGroup??typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
                 It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }
@@ -292,8 +292,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
 
             #region Verify
             serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
-                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
-                mappedGroup,
+                mappedChannel??typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name,
+                mappedGroup??typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,
                 It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }

--- a/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
@@ -1,0 +1,330 @@
+﻿using AutomatedTesting.Messages;
+using Moq;
+using MQContract.Attributes;
+using MQContract.Interfaces.Service;
+using MQContract.Interfaces;
+using MQContract;
+using System.Diagnostics;
+using MQContract.Interfaces.Consumers;
+using System.Reflection;
+using AutomatedTesting.Consumers;
+
+namespace AutomatedTesting.ConnectionTests.Consumers
+{
+    [TestClass]
+    public class QueryResponseAsyncConsumerTests
+    {
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsAndSuppliedInstance()
+        {
+            #region Arrange
+            var acknowledged = false;
+
+            var serviceSubscription = new Mock<IServiceSubscription>();
+
+            var receivedActions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(
+                Capture.In(receivedActions),
+                Capture.In(errorActions),
+                Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.QueryAsync(It.IsAny<ServiceMessage>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .Returns(async (ServiceMessage message, TimeSpan timeout, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    var result = await receivedActions[0](rmessage);
+                    return Helper.ProduceQueryResult(result);
+                });
+
+            var messages = new List<IReceivedMessage<BasicQueryMessage>>();
+            var exceptions = new List<Exception>();
+
+            var message = new BasicQueryMessage("TestSubscribeQueryResponseWithNoExtendedAspects");
+            var responseMessage = new BasicResponseMessage("TestSubscribeQueryResponseWithNoExtendedAspects");
+            var exception = new NullReferenceException("TestSubscribeQueryResponseWithNoExtendedAspects");
+
+            var mockAsyncConsumer = new Mock<IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>>();
+            mockAsyncConsumer.Setup(x => x.ErrorRecieved(Capture.In(exceptions)));
+            mockAsyncConsumer.Setup(x => x.MessageReceivedAsync(Capture.In(messages)))
+                .Returns(ValueTask.FromResult<QueryResponseMessage<BasicResponseMessage>>(new(responseMessage)));
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync<BasicQueryMessage, BasicResponseMessage, IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>>(mockAsyncConsumer.Object);
+            var result = await contractConnection.QueryAsync<BasicQueryMessage>(message);
+            foreach (var act in errorActions)
+                act(exception);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, receivedActions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(1, exceptions.Count);
+            Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+            Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+            Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+            Assert.AreEqual(message, messages[0].Message);
+            Assert.AreEqual(exception, exceptions[0]);
+            Assert.IsFalse(result.IsError);
+            Assert.IsNull(result.Error);
+            Assert.AreEqual(result.Result, responseMessage);
+            Assert.IsTrue(acknowledged);
+            Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.QueryAsync(It.IsAny<ServiceMessage>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", null)]
+        [DataRow(null, "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsAndSuppliedInstanceWithParameters(string? channel, string? group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var mockAsyncConsumer = new Mock<IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>>();
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync<BasicQueryMessage, BasicResponseMessage, IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>>(mockAsyncConsumer.Object, channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsWithoutInstance()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            var actions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync<BasicQueryMessage, BasicResponseMessage, BasicQueryAsyncConsumer>();
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
+            Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name,groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsWithoutInstanceWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync<BasicQueryMessage, BasicResponseMessage, BasicQueryAsyncConsumer>(channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            var actions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync(typeof(BasicQueryAsyncConsumer));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
+            Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingTypeWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseAsyncConsumerAsync(typeof(BasicQueryAsyncConsumer), channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckRegistrationUsingTypeWithInvalidType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var error = await Assert.ThrowsAsync<InvalidConsumerType>(async () => await contractConnection.RegisterQueryResponseAsyncConsumerAsync(typeof(QueryResponseAsyncConsumerTests)));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(error);
+            Assert.AreEqual($"Unable to register consumer of Type {typeof(QueryResponseAsyncConsumerTests).FullName} because it does not implement the interface {typeof(IQueryResponseAsyncConsumer<,>).Name}",
+                error.Message);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            #endregion
+        }
+    }
+}

--- a/AutomatedTesting/ConnectionTests/Consumers/QueryResponseConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/QueryResponseConsumerTests.cs
@@ -1,0 +1,330 @@
+﻿using AutomatedTesting.Messages;
+using Moq;
+using MQContract.Attributes;
+using MQContract.Interfaces.Service;
+using MQContract.Interfaces;
+using MQContract;
+using System.Diagnostics;
+using MQContract.Interfaces.Consumers;
+using System.Reflection;
+using AutomatedTesting.Consumers;
+
+namespace AutomatedTesting.ConnectionTests.Consumers
+{
+    [TestClass]
+    public class QueryResponseConsumerTests
+    {
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsAndSuppliedInstance()
+        {
+            #region Arrange
+            var acknowledged = false;
+
+            var serviceSubscription = new Mock<IServiceSubscription>();
+
+            var receivedActions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(
+                Capture.In(receivedActions),
+                Capture.In(errorActions),
+                Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.QueryAsync(It.IsAny<ServiceMessage>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .Returns(async (ServiceMessage message, TimeSpan timeout, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    var result = await receivedActions[0](rmessage);
+                    return Helper.ProduceQueryResult(result);
+                });
+
+            var messages = new List<IReceivedMessage<BasicQueryMessage>>();
+            var exceptions = new List<Exception>();
+
+            var message = new BasicQueryMessage("TestSubscribeQueryResponseWithNoExtendedAspects");
+            var responseMessage = new BasicResponseMessage("TestSubscribeQueryResponseWithNoExtendedAspects");
+            var exception = new NullReferenceException("TestSubscribeQueryResponseWithNoExtendedAspects");
+
+            var mockConsumer = new Mock<IQueryResponseConsumer<BasicQueryMessage,BasicResponseMessage>>();
+            mockConsumer.Setup(x => x.ErrorRecieved(Capture.In(exceptions)));
+            mockConsumer.Setup(x => x.MessageReceived(Capture.In(messages)))
+                .Returns(new QueryResponseMessage<BasicResponseMessage>(responseMessage));
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync<BasicQueryMessage,BasicResponseMessage, IQueryResponseConsumer<BasicQueryMessage,BasicResponseMessage>>(mockConsumer.Object);
+            var result = await contractConnection.QueryAsync<BasicQueryMessage>(message);
+            foreach (var act in errorActions)
+                act(exception);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, receivedActions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(1, exceptions.Count);
+            Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+            Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+            Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+            Assert.AreEqual(message, messages[0].Message);
+            Assert.AreEqual(exception, exceptions[0]);
+            Assert.IsFalse(result.IsError);
+            Assert.IsNull(result.Error);
+            Assert.AreEqual(result.Result, responseMessage);
+            Assert.IsTrue(acknowledged);
+            Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.QueryAsync(It.IsAny<ServiceMessage>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x=>x.EndAsync(), Times.Once);    
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel",null)]
+        [DataRow(null, "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsAndSuppliedInstanceWithParameters(string? channel,string? group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var mockConsumer = new Mock<IQueryResponseConsumer<BasicQueryMessage, BasicResponseMessage>>();
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync<BasicQueryMessage,BasicResponseMessage, IQueryResponseConsumer<BasicQueryMessage, BasicResponseMessage>>(mockConsumer.Object,channel:mappedChannel,group:mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup, 
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingGenericsWithoutInstance()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            var actions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+            
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync<BasicQueryMessage, BasicResponseMessage, BasicQueryConsumer>();
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingGenericsWithoutInstanceWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync<BasicQueryMessage, BasicResponseMessage, BasicQueryConsumer>(channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckDefaultRegistrationUsingType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            var actions = new List<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>();
+            var errorActions = new List<Action<Exception>>();
+            var channels = new List<string>();
+            var groups = new List<string?>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(Capture.In(actions), Capture.In(errorActions), Capture.In(channels),
+                Capture.In(groups), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync(typeof(BasicQueryConsumer));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, channels.Count);
+            Assert.AreEqual(1, groups.Count);
+            Assert.AreEqual(1, errorActions.Count);
+            Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
+            Assert.IsNull(groups[0]);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        [DataRow("TestChannel", "")]
+        [DataRow("", "TestGroup")]
+        public async ValueTask CheckRegistrationUsingTypeWithParameters(string channel, string group)
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+
+            var mappedChannel = string.IsNullOrWhiteSpace(channel) ? null : channel;
+            var mappedGroup = string.IsNullOrEmpty(group) ? null : group;
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterQueryResponseConsumerAsync(typeof(BasicQueryConsumer),channel: mappedChannel, group: mappedGroup);
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(),
+                mappedChannel??typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)!.Name,
+                mappedGroup,
+                It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
+
+        [TestMethod()]
+        public async ValueTask CheckRegistrationUsingTypeWithInvalidType()
+        {
+            #region Arrange
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IQueryResponseMessageServiceConnection>();
+
+            serviceConnection.Setup(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var error = await Assert.ThrowsAsync<InvalidConsumerType>(async()=>await contractConnection.RegisterQueryResponseConsumerAsync(typeof(QueryResponseConsumerTests)));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(error);
+            Assert.AreEqual($"Unable to register consumer of Type {typeof(QueryResponseConsumerTests).FullName} because it does not implement the interface {typeof(IQueryResponseConsumer<,>).Name}",
+                error.Message);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeQueryAsync(It.IsAny<Func<ReceivedServiceMessage, ValueTask<ServiceMessage>>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            #endregion
+        }
+    }
+}

--- a/AutomatedTesting/Consumers/BasicMessageAsyncConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicMessageAsyncConsumer.cs
@@ -1,0 +1,18 @@
+﻿using AutomatedTesting.Messages;
+using MQContract.Attributes;
+using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace AutomatedTesting.Consumers
+{
+    [ConsumerMessageChannel("AsyncBasicMessage")]
+    [ConsumerGroup("AsyncBasicMessageGroup")]
+    internal class BasicMessageAsyncConsumer : IPubSubAsyncConsumer<BasicMessage>
+    {
+        void IBaseConsumer.ErrorRecieved(Exception error)
+        { }
+
+        ValueTask IPubSubAsyncConsumer<BasicMessage>.MessageReceivedAsync(IReceivedMessage<BasicMessage> message)
+        => ValueTask.CompletedTask;
+    }
+}

--- a/AutomatedTesting/Consumers/BasicMessageConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicMessageConsumer.cs
@@ -1,0 +1,15 @@
+﻿using AutomatedTesting.Messages;
+using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace AutomatedTesting.Consumers
+{
+    internal class BasicMessageConsumer : IPubSubConsumer<BasicMessage>
+    {
+        void IBaseConsumer.ErrorRecieved(Exception error)
+        {}
+
+        void IPubSubConsumer<BasicMessage>.MessageReceived(IReceivedMessage<BasicMessage> message)
+        {}
+    }
+}

--- a/AutomatedTesting/Consumers/BasicQueryAsyncConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicQueryAsyncConsumer.cs
@@ -1,0 +1,18 @@
+﻿using AutomatedTesting.Messages;
+using MQContract.Attributes;
+using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace AutomatedTesting.Consumers
+{
+    [ConsumerMessageChannel("AsyncBasicQueryMessage")]
+    [ConsumerGroup("AsyncBasicQueryMessageGroup")]
+    internal class BasicQueryAsyncConsumer : IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>
+    {
+        void IBaseConsumer.ErrorRecieved(Exception error)
+        { }
+
+        ValueTask<QueryResponseMessage<BasicResponseMessage>> IQueryResponseAsyncConsumer<BasicQueryMessage, BasicResponseMessage>.MessageReceivedAsync(IReceivedMessage<BasicQueryMessage> message)
+        => ValueTask.FromResult<QueryResponseMessage<BasicResponseMessage>>(new(new(message.Message.TypeName)));
+    }
+}

--- a/AutomatedTesting/Consumers/BasicQueryConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicQueryConsumer.cs
@@ -1,0 +1,15 @@
+﻿using AutomatedTesting.Messages;
+using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace AutomatedTesting.Consumers
+{
+    internal class BasicQueryConsumer : IQueryResponseConsumer<BasicQueryMessage, BasicResponseMessage>
+    {
+        void IBaseConsumer.ErrorRecieved(Exception error)
+        { }
+
+        QueryResponseMessage<BasicResponseMessage> IQueryResponseConsumer<BasicQueryMessage, BasicResponseMessage>.MessageReceived(IReceivedMessage<BasicQueryMessage> message)
+        => new(new(message.Message.TypeName));
+    }
+}

--- a/AutomatedTesting/DefaultEncodersTests.cs
+++ b/AutomatedTesting/DefaultEncodersTests.cs
@@ -115,58 +115,6 @@ namespace AutomatedTesting
             #endregion
         }
 
-        [TestMethod]
-        public async Task TestByteEncoder()
-        {
-            #region Arrange
-            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
-            var serviceSubscription = new Mock<IServiceSubscription>();
-
-            var testMessage = RandomNumberGenerator.GetBytes(1)[0];
-
-            List<ServiceMessage> serviceMessages = [];
-            var actions = new List<Action<ReceivedServiceMessage>>();
-            var recievedMessages = new List<IReceivedMessage<byte>>();
-
-            var serviceConnection = new Mock<IMessageServiceConnection>();
-            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(serviceSubscription.Object);
-            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
-                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
-                {
-                    var rmessage = Helper.ProduceReceivedServiceMessage(message);
-                    serviceMessages.Add(rmessage);
-                    foreach (var act in actions)
-                        act(rmessage);
-                    return ValueTask.FromResult(transmissionResult);
-                });
-
-            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
-            #endregion
-
-            #region Act
-            var subscription = await contractConnection.SubscribeAsync<byte>((msg) => recievedMessages.Add(msg), (err) => { }, ChannelName);
-            var result = await contractConnection.PublishAsync<byte>(testMessage, ChannelName);
-            #endregion
-
-            #region Assert
-            Assert.IsTrue(await Helper.WaitForCount(recievedMessages, 1, TimeSpan.FromMinutes(1)));
-
-            await subscription.EndAsync();
-
-            Assert.IsNotNull(result);
-            Assert.AreEqual(transmissionResult, result);
-            Assert.AreEqual(testMessage, recievedMessages[0].Message);
-            Assert.IsTrue(Enumerable.SequenceEqual<byte>([testMessage], serviceMessages[0].Data.ToArray()));
-            #endregion
-
-            #region Verify
-            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
-            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-            #endregion
-        }
-
         private async Task BitConverterTypeTest<T>(T testMessage, byte[] convertedValue)
         {
             #region Arrange
@@ -214,6 +162,13 @@ namespace AutomatedTesting
             serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
             serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             #endregion
+        }
+
+        [TestMethod]
+        public async Task TestByteEncoder()
+        {
+            var binaryData = RandomNumberGenerator.GetBytes(sizeof(byte));
+            await BitConverterTypeTest<byte>(binaryData[0], binaryData);
         }
 
         [TestMethod]

--- a/AutomatedTesting/DefaultEncodersTests.cs
+++ b/AutomatedTesting/DefaultEncodersTests.cs
@@ -1,12 +1,8 @@
-﻿using AutomatedTesting.Messages;
-using Moq;
-using MQContract.Attributes;
+﻿using Moq;
 using MQContract.Interfaces.Service;
 using MQContract;
-using System.Diagnostics;
 using System.Security.Cryptography;
 using MQContract.Interfaces;
-using System.Runtime.InteropServices;
 
 namespace AutomatedTesting
 {

--- a/AutomatedTesting/Helper.cs
+++ b/AutomatedTesting/Helper.cs
@@ -29,7 +29,7 @@ namespace AutomatedTesting
                     Task.Delay(Delay).Wait();
             });
             task.Start();
-            return await Task.WhenAny(task, Task.Delay(maxTime)) == task;
+            return (await Task.WhenAny(task, Task.Delay(maxTime))) == task || values.Count()>=count;
         }
     }
 }

--- a/Connectors/ApachePulsar/ApachePulsar.csproj
+++ b/Connectors/ApachePulsar/ApachePulsar.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DotPulsar" Version="4.0.0" />
+		<PackageReference Include="DotPulsar" Version="4.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Connectors/AzureServiceBus/AzureServiceBus.csproj
+++ b/Connectors/AzureServiceBus/AzureServiceBus.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.3" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Connectors/GooglePubSub/GooglePubSub.csproj
+++ b/Connectors/GooglePubSub/GooglePubSub.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Google.Cloud.PubSub.V1" Version="3.20.0" />
+		<PackageReference Include="Google.Cloud.PubSub.V1" Version="3.21.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Connectors/NATS/NATS.csproj
+++ b/Connectors/NATS/NATS.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NATS.Net" Version="2.5.7" />
+    <PackageReference Include="NATS.Net" Version="2.5.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/Connections/AConnection.Consumers.cs
+++ b/Core/Connections/AConnection.Consumers.cs
@@ -1,13 +1,102 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MQContract.Attributes;
 using MQContract.Interfaces;
 using MQContract.Interfaces.Consumers;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading.Channels;
 
 namespace MQContract.Connections
 {
     internal abstract partial class AConnection<CC> : IMetricContractConnection<CC>
         where CC : IBaseContractConnection
     {
+        private async ValueTask<bool> RegisterSubscription(Func<string?, string?, bool, ValueTask<ISubscription>> createSubscription,
+            string? channel, string? group, bool ignoreMessageHeader, string consumerName, Type consumerType, CancellationToken cancellationToken)
+        {
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                consumerSubscriptions.Add(await createSubscription(
+                    channel??consumerType.GetCustomAttribute<ConsumerMessageChannelAttribute>()?.Name,
+                    group??consumerType.GetCustomAttribute<ConsumerGroupAttribute>()?.Name,
+                    ignoreMessageHeader||(consumerType.GetCustomAttribute<ConsumerIgnoreMessageHeaderAttribute>()?.IgnoreHeader??false)
+                ));
+                return true;
+            }
+            catch (Exception err)
+            {
+                logger?.LogError(err, "An error occured attempting to register a {ConsumerName} of type {ConsumerType}", consumerName,consumerType);
+                return false;
+            }
+            finally
+            {
+                inboxSemaphore.Release();
+            }
+        }
+
+        private static Type GetConsumerInterfaceType(Type consumerType,Type interfaceType)
+            => Array.Find(consumerType.GetInterfaces(),t=>t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType)
+                ??throw new InvalidConsumerType(consumerType, interfaceType);
+
+        private readonly List<Assembly> loadedAssemblies = [];
+
+        private static readonly Type[] LoadableTypes = [typeof(IPubSubConsumer<>), typeof(IPubSubAsyncConsumer<>),
+        typeof(IQueryResponseConsumer<,>),typeof(IQueryResponseAsyncConsumer<,>)];
+
+        private async Task<bool> LoadConsumersForAssemblyAsync(Assembly assembly,CancellationToken cancellationToken)
+        {
+            var process = false;
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            if (!loadedAssemblies.Contains(assembly))
+            {
+                process=true;
+                loadedAssemblies.Add(assembly);
+            }
+            inboxSemaphore.Release();
+            if (process)
+            {
+                var loadablePairs = assembly.GetTypes()
+                    .Select(consumerType => new { ConsumerType=consumerType,InterfaceType=Array.Find(consumerType.GetInterfaces(), t => t.IsGenericType && LoadableTypes.Contains(t.GetGenericTypeDefinition()))})
+                    .Where(pair=>pair.InterfaceType!=null)
+                    .ToArray();
+                foreach(var consumerPair in loadablePairs)
+                {
+                    if (consumerPair.InterfaceType==typeof(IPubSubConsumer<>)
+                        && !(await ((IConsumerContractConnection)this).RegisterPubSubConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                        return false;
+                    else if (consumerPair.InterfaceType==typeof(IPubSubAsyncConsumer<>)
+                        && !(await ((IConsumerContractConnection)this).RegisterPubSubAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                        return false;
+                    else if (consumerPair.InterfaceType==typeof(IQueryResponseConsumer<,>)
+                        && !(await ((IConsumerContractConnection)this).RegisterQueryResponseConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                        return false;
+                    else if (consumerPair.InterfaceType==typeof(IQueryResponseAsyncConsumer<,>)
+                        && !(await ((IConsumerContractConnection)this).RegisterQueryResponseAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                        return false;
+                    else
+                        return false;
+                }
+            }
+            return true;
+        }
+
+        async ValueTask<bool> IConsumerContractConnection.AutoRegisterAllConsumersAsync(Assembly? assembly,CancellationToken cancellationToken)
+        {
+            if (assembly!=null)
+                return await LoadConsumersForAssemblyAsync(assembly!,cancellationToken);
+            else
+            {
+                foreach (var asm in AssemblyLoadContext.Default.Assemblies)
+                {
+                    if (!(await LoadConsumersForAssemblyAsync(asm,cancellationToken)))
+                        return false;
+                }
+                return true;
+            }
+        }
+
         #region PubSubConsumer
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
             => CreatePubSubConsumerSubscriptionAsync<T>(consumer, channel, group, ignoreMessageHeader, cancellationToken);
@@ -23,9 +112,7 @@ namespace MQContract.Connections
 
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
-            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IPubSubConsumer<>));
-            if (ifaceType==null)
-                throw new Exception("Unable to register consumer that does not implement the interface IPubSubConsumer<>");
+            var ifaceType = GetConsumerInterfaceType(consumerType,typeof(IPubSubConsumer<>));
             var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubConsumerSubscriptionAsync))?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
@@ -37,12 +124,8 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private async ValueTask<bool> CreatePubSubConsumerSubscriptionAsync<T>(IPubSubConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
-        {
-            await inboxSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                consumerSubscriptions.Add(await CreateSubscriptionAsync<T>(
+        private ValueTask<bool> CreatePubSubConsumerSubscriptionAsync<T>(IPubSubConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) =>
                     {
                         consumer.MessageReceived(message);
@@ -54,19 +137,14 @@ namespace MQContract.Connections
                     ignoreMessageHeader,
                     true,
                     cancellationToken
-                ));
-                return true;
-            }
-            catch (Exception err)
-            {
-                logger?.LogError(err, "An error occured attempting to register a PubSubConsumer of type {Type}", consumer.GetType());
-                return false;
-            }
-            finally
-            {
-                inboxSemaphore.Release();
-            }
-        }
+                ),
+                channel, 
+                group, 
+                ignoreMessageHeader,
+                "PubSubConsumer", 
+                consumer.GetType(),
+                cancellationToken
+            );
 
         #endregion
 
@@ -85,9 +163,7 @@ namespace MQContract.Connections
 
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
-            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IPubSubAsyncConsumer<>));
-            if (ifaceType==null)
-                throw new Exception("Unable to register consumer that does not implement the interface IPubSubAsyncConsumer<>");
+            var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IPubSubAsyncConsumer<>));
             var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubAsyncConsumerSubscriptionAsync))?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
@@ -99,12 +175,8 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private async ValueTask<bool> CreatePubSubAsyncConsumerSubscriptionAsync<T>(IPubSubAsyncConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
-        {
-            await inboxSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                consumerSubscriptions.Add(await CreateSubscriptionAsync<T>(
+        private ValueTask<bool> CreatePubSubAsyncConsumerSubscriptionAsync<T>(IPubSubAsyncConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) => consumer.MessageReceivedAsync(message),
                     (error) => consumer.ErrorRecieved(error),
                     channel,
@@ -112,19 +184,14 @@ namespace MQContract.Connections
                     ignoreMessageHeader,
                     true,
                     cancellationToken
-                ));
-                return true;
-            }
-            catch (Exception err)
-            {
-                logger?.LogError(err, "An error occured attempting to register a PubSubAsyncConsumer of type {Type}", consumer.GetType());
-                return false;
-            }
-            finally
-            {
-                inboxSemaphore.Release();
-            }
-        }
+                ),
+                channel, 
+                group, 
+                ignoreMessageHeader,
+                "PubSubAsyncConsumer", 
+                consumer.GetType(),
+                cancellationToken
+            );
 
         #endregion
 
@@ -143,9 +210,7 @@ namespace MQContract.Connections
 
         ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
-            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IQueryResponseConsumer<,>));
-            if (ifaceType==null)
-                throw new Exception("Unable to register consumer that does not implement the interface IQueryResponseConsumer<,>");
+            var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IQueryResponseConsumer<,>));
             var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseConsumerSubscriptionAsync))?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
@@ -157,12 +222,8 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private async ValueTask<bool> CreateQueryResponseConsumerSubscriptionAsync<Q, R>(IQueryResponseConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
-        {
-            await inboxSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                consumerSubscriptions.Add(await ProduceSubscribeQueryResponseAsync<Q,R>(
+        private ValueTask<bool> CreateQueryResponseConsumerSubscriptionAsync<Q, R>(IQueryResponseConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+             => RegisterSubscription((channel, group, ignoreMessageHeader) => ProduceSubscribeQueryResponseAsync<Q, R>(
                     (message) => ValueTask.FromResult(consumer.MessageReceived(message)),
                     (error) => consumer.ErrorRecieved(error),
                     channel,
@@ -170,19 +231,14 @@ namespace MQContract.Connections
                     ignoreMessageHeader,
                     true,
                     cancellationToken
-                ));
-                return true;
-            }
-            catch (Exception err)
-            {
-                logger?.LogError(err, "An error occured attempting to register a QueryResponseConsumer of type {Type}", consumer.GetType());
-                return false;
-            }
-            finally
-            {
-                inboxSemaphore.Release();
-            }
-        }
+                ),
+                channel, 
+                group, 
+                ignoreMessageHeader,
+                "QueryResponseConsumer", 
+                consumer.GetType(),
+                cancellationToken
+             );
 
         #endregion
 
@@ -201,9 +257,7 @@ namespace MQContract.Connections
 
         ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
-            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IQueryResponseAsyncConsumer<,>));
-            if (ifaceType==null)
-                throw new Exception("Unable to register consumer that does not implement the interface IQueryResponseAsyncConsumer<,>");
+            var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IQueryResponseAsyncConsumer<,>));
             var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseAsyncConsumerSubscriptionAsync))?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
@@ -215,33 +269,23 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private async ValueTask<bool> CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(IQueryResponseAsyncConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
-        {
-            await inboxSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                consumerSubscriptions.Add(await ProduceSubscribeQueryResponseAsync<Q,R>(
-                    (message) =>consumer.MessageReceivedAsync(message),
+        private ValueTask<bool> CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(IQueryResponseAsyncConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => RegisterSubscription((channel, group, ignoreMessageHeader) => ProduceSubscribeQueryResponseAsync<Q, R>(
+                    (message) => consumer.MessageReceivedAsync(message),
                     (error) => consumer.ErrorRecieved(error),
                     channel,
                     group,
                     ignoreMessageHeader,
                     true,
                     cancellationToken
-                ));
-                return true;
-            }
-            catch (Exception err)
-            {
-                logger?.LogError(err, "An error occured attempting to register a QueryResponseAsyncConsumer of type {Type}", consumer.GetType());
-                return false;
-            }
-            finally
-            {
-                inboxSemaphore.Release();
-            }
-        }
-
+                ),
+                channel, 
+                group, 
+                ignoreMessageHeader,
+                "QueryResponseAsyncConsumer", 
+                consumer.GetType(),
+                cancellationToken
+            );
         #endregion
     }
 }

--- a/Core/Connections/AConnection.Consumers.cs
+++ b/Core/Connections/AConnection.Consumers.cs
@@ -13,29 +13,29 @@ namespace MQContract.Connections
 #pragma warning restore S3881 // "IDisposable" should be implemented correctly
         where CC : IBaseContractConnection
     {
-        private async ValueTask<bool> RegisterSubscription(Func<string?, string?, bool, ValueTask<ISubscription>> createSubscription,
+        private async ValueTask<bool> RegisterSubscription(Func<string?, string?, bool, ValueTask<ISubscription?>> createSubscription,
             string? channel, string? group, bool ignoreMessageHeader, string consumerName, Type consumerType, CancellationToken cancellationToken)
         {
-            await inboxSemaphore.WaitAsync(cancellationToken);
+            ISubscription? subscription = null;
             try
             {
-                consumerSubscriptions.Add(await createSubscription(
+                subscription = await createSubscription(
                     channel??consumerType.GetCustomAttribute<ConsumerMessageChannelAttribute>()?.Name,
                     group??consumerType.GetCustomAttribute<ConsumerGroupAttribute>()?.Name,
                     ignoreMessageHeader||(consumerType.GetCustomAttribute<ConsumerIgnoreMessageHeaderAttribute>()?.IgnoreHeader??false)
-                ));
-                return true;
+                );
             }
             catch (Exception err)
             {
-                logger?.LogError(err, "An error occured attempting to register a {ConsumerName} of type {ConsumerType}", consumerName,consumerType);
+                logger?.LogError(err, "An error occured attempting to register a {ConsumerName} of type {ConsumerType}", consumerName, consumerType);
                 return false;
             }
-            finally
-            {
-                inboxSemaphore.Release();
-            }
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            consumerSubscriptions.Add(subscription!);
+            inboxSemaphore.Release();
+            return true;
         }
+        
 
         private static Type GetConsumerInterfaceType(Type consumerType,Type interfaceType)
             => Array.Find(consumerType.GetInterfaces(),t=>t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType)
@@ -58,25 +58,43 @@ namespace MQContract.Connections
             inboxSemaphore.Release();
             if (process)
             {
-                var loadablePairs = assembly.GetTypes()
-                    .Select(consumerType => new { ConsumerType=consumerType,InterfaceType=Array.Find(consumerType.GetInterfaces(), t => t.IsGenericType && LoadableTypes.Contains(t.GetGenericTypeDefinition()))})
+                Type[] types = [];
+                try
+                {
+                    types=assembly.GetTypes()
+                        .Where(t => !t.IsInterface && !t.IsAbstract && !(t.FullName?.StartsWith("Castle.Proxies")??false))
+                        .ToArray();
+                }
+                catch { 
+                    //Ignoring the exception as this is just to prevent a loading issue.
+                }
+                var loadablePairs = types
+                    .Select(consumerType => new { 
+                        ConsumerType=consumerType,
+                        InterfaceType=Array.Find(consumerType.GetInterfaces(),
+                            t => t.IsGenericType && LoadableTypes.Contains(t.GetGenericTypeDefinition()))
+                    })
                     .Where(pair=>pair.InterfaceType!=null)
                     .ToArray();
                 foreach(var consumerPair in loadablePairs)
                 {
-                    if (consumerPair.InterfaceType==typeof(IPubSubConsumer<>)
-                        && !(await ((IConsumerContractConnection)this).RegisterPubSubConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
-                        return false;
-                    else if (consumerPair.InterfaceType==typeof(IPubSubAsyncConsumer<>)
-                        && !(await ((IConsumerContractConnection)this).RegisterPubSubAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
-                        return false;
-                    else if (consumerPair.InterfaceType==typeof(IQueryResponseConsumer<,>)
-                        && !(await ((IConsumerContractConnection)this).RegisterQueryResponseConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
-                        return false;
-                    else if (consumerPair.InterfaceType==typeof(IQueryResponseAsyncConsumer<,>)
-                        && !(await ((IConsumerContractConnection)this).RegisterQueryResponseAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
-                        return false;
-                    else
+                    if (Equals(consumerPair.InterfaceType?.GetGenericTypeDefinition(), typeof(IPubSubConsumer<>)))
+                    {
+                        if (!(await ((IConsumerContractConnection)this).RegisterPubSubConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                            return false;
+                    }
+                    else if (Equals(consumerPair.InterfaceType?.GetGenericTypeDefinition(), typeof(IPubSubAsyncConsumer<>)))
+                    {
+                        if (!(await ((IConsumerContractConnection)this).RegisterPubSubAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                            return false;
+                    }
+                    else if (Equals(consumerPair.InterfaceType?.GetGenericTypeDefinition(), typeof(IQueryResponseConsumer<,>)))
+                    {
+                        if (!(await ((IConsumerContractConnection)this).RegisterQueryResponseConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
+                            return false;
+                    }
+                    else if (Equals(consumerPair.InterfaceType?.GetGenericTypeDefinition(), typeof(IQueryResponseAsyncConsumer<,>))
+                        &&!(await ((IConsumerContractConnection)this).RegisterQueryResponseAsyncConsumerAsync(consumerPair.ConsumerType, cancellationToken: cancellationToken)))
                         return false;
                 }
             }
@@ -114,8 +132,10 @@ namespace MQContract.Connections
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType,typeof(IPubSubConsumer<>));
-            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubConsumerSubscriptionAsync))?
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            var methodinfo = GetType().GetMethod(nameof(AConnection<CC>.CreatePubSubConsumerSubscriptionAsync), BindingFlags.Instance|BindingFlags.NonPublic)?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
                 (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
                 channel,
@@ -125,7 +145,7 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private ValueTask<bool> CreatePubSubConsumerSubscriptionAsync<T>(IPubSubConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        protected ValueTask<bool> CreatePubSubConsumerSubscriptionAsync<T>(IPubSubConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
             => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) =>
                     {
@@ -165,8 +185,10 @@ namespace MQContract.Connections
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IPubSubAsyncConsumer<>));
-            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubAsyncConsumerSubscriptionAsync))?
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            var methodinfo = GetType().GetMethod(nameof(AConnection<CC>.CreatePubSubAsyncConsumerSubscriptionAsync), BindingFlags.Instance|BindingFlags.NonPublic)?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
                 (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
                 channel,
@@ -176,7 +198,7 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private ValueTask<bool> CreatePubSubAsyncConsumerSubscriptionAsync<T>(IPubSubAsyncConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        protected ValueTask<bool> CreatePubSubAsyncConsumerSubscriptionAsync<T>(IPubSubAsyncConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
             => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) => consumer.MessageReceivedAsync(message),
                     (error) => consumer.ErrorRecieved(error),
@@ -212,8 +234,10 @@ namespace MQContract.Connections
         ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IQueryResponseConsumer<,>));
-            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseConsumerSubscriptionAsync))?
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            var methodinfo = GetType().GetMethod(nameof(AConnection<CC>.CreateQueryResponseConsumerSubscriptionAsync), BindingFlags.Instance|BindingFlags.NonPublic)?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
                 (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
                 channel,
@@ -223,7 +247,7 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private ValueTask<bool> CreateQueryResponseConsumerSubscriptionAsync<Q, R>(IQueryResponseConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        protected ValueTask<bool> CreateQueryResponseConsumerSubscriptionAsync<Q, R>(IQueryResponseConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
              => RegisterSubscription((channel, group, ignoreMessageHeader) => ProduceSubscribeQueryResponseAsync<Q, R>(
                     (message) => ValueTask.FromResult(consumer.MessageReceived(message)),
                     (error) => consumer.ErrorRecieved(error),
@@ -259,8 +283,10 @@ namespace MQContract.Connections
         ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IQueryResponseAsyncConsumer<,>));
-            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseAsyncConsumerSubscriptionAsync))?
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            var methodinfo = GetType().GetMethod(nameof(AConnection<CC>.CreateQueryResponseAsyncConsumerSubscriptionAsync), BindingFlags.Instance|BindingFlags.NonPublic)?
                 .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return (ValueTask<bool>)methodinfo!.Invoke(this, [
                 (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
                 channel,
@@ -270,7 +296,7 @@ namespace MQContract.Connections
             ])!;
         }
 
-        private ValueTask<bool> CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(IQueryResponseAsyncConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        protected ValueTask<bool> CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(IQueryResponseAsyncConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
             => RegisterSubscription((channel, group, ignoreMessageHeader) => ProduceSubscribeQueryResponseAsync<Q, R>(
                     (message) => consumer.MessageReceivedAsync(message),
                     (error) => consumer.ErrorRecieved(error),

--- a/Core/Connections/AConnection.Consumers.cs
+++ b/Core/Connections/AConnection.Consumers.cs
@@ -5,11 +5,12 @@ using MQContract.Interfaces;
 using MQContract.Interfaces.Consumers;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Threading.Channels;
 
 namespace MQContract.Connections
 {
+#pragma warning disable S3881 // "IDisposable" should be implemented correctly
     internal abstract partial class AConnection<CC> : IMetricContractConnection<CC>
+#pragma warning restore S3881 // "IDisposable" should be implemented correctly
         where CC : IBaseContractConnection
     {
         private async ValueTask<bool> RegisterSubscription(Func<string?, string?, bool, ValueTask<ISubscription>> createSubscription,
@@ -42,8 +43,8 @@ namespace MQContract.Connections
 
         private readonly List<Assembly> loadedAssemblies = [];
 
-        private static readonly Type[] LoadableTypes = [typeof(IPubSubConsumer<>), typeof(IPubSubAsyncConsumer<>),
-        typeof(IQueryResponseConsumer<,>),typeof(IQueryResponseAsyncConsumer<,>)];
+        private static Type[] LoadableTypes => [typeof(IPubSubConsumer<>), typeof(IPubSubAsyncConsumer<>),
+                    typeof(IQueryResponseConsumer<,>),typeof(IQueryResponseAsyncConsumer<,>)];
 
         private async Task<bool> LoadConsumersForAssemblyAsync(Assembly assembly,CancellationToken cancellationToken)
         {

--- a/Core/Connections/AConnection.Consumers.cs
+++ b/Core/Connections/AConnection.Consumers.cs
@@ -1,0 +1,247 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace MQContract.Connections
+{
+    internal abstract partial class AConnection<CC> : IMetricContractConnection<CC>
+        where CC : IBaseContractConnection
+    {
+        #region PubSubConsumer
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreatePubSubConsumerSubscriptionAsync<T>(consumer, channel, group, ignoreMessageHeader, cancellationToken);
+
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreatePubSubConsumerSubscriptionAsync<T>(
+                (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            );
+
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IPubSubConsumer<>));
+            if (ifaceType==null)
+                throw new Exception("Unable to register consumer that does not implement the interface IPubSubConsumer<>");
+            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubConsumerSubscriptionAsync))?
+                .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
+            return (ValueTask<bool>)methodinfo!.Invoke(this, [
+                (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            ])!;
+        }
+
+        private async ValueTask<bool> CreatePubSubConsumerSubscriptionAsync<T>(IPubSubConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                consumerSubscriptions.Add(await CreateSubscriptionAsync<T>(
+                    (message) =>
+                    {
+                        consumer.MessageReceived(message);
+                        return ValueTask.CompletedTask;
+                    },
+                    (error) => consumer.ErrorRecieved(error),
+                    channel,
+                    group,
+                    ignoreMessageHeader,
+                    true,
+                    cancellationToken
+                ));
+                return true;
+            }
+            catch (Exception err)
+            {
+                logger?.LogError(err, "An error occured attempting to register a PubSubConsumer of type {Type}", consumer.GetType());
+                return false;
+            }
+            finally
+            {
+                inboxSemaphore.Release();
+            }
+        }
+
+        #endregion
+
+        #region PubSubAsyncConsumer
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreatePubSubAsyncConsumerSubscriptionAsync<T>(consumer, channel, group, ignoreMessageHeader, cancellationToken);
+
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreatePubSubAsyncConsumerSubscriptionAsync<T>(
+                (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            );
+
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IPubSubAsyncConsumer<>));
+            if (ifaceType==null)
+                throw new Exception("Unable to register consumer that does not implement the interface IPubSubAsyncConsumer<>");
+            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreatePubSubAsyncConsumerSubscriptionAsync))?
+                .MakeGenericMethod(ifaceType.GetGenericArguments()[0]);
+            return (ValueTask<bool>)methodinfo!.Invoke(this, [
+                (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            ])!;
+        }
+
+        private async ValueTask<bool> CreatePubSubAsyncConsumerSubscriptionAsync<T>(IPubSubAsyncConsumer<T> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                consumerSubscriptions.Add(await CreateSubscriptionAsync<T>(
+                    (message) => consumer.MessageReceivedAsync(message),
+                    (error) => consumer.ErrorRecieved(error),
+                    channel,
+                    group,
+                    ignoreMessageHeader,
+                    true,
+                    cancellationToken
+                ));
+                return true;
+            }
+            catch (Exception err)
+            {
+                logger?.LogError(err, "An error occured attempting to register a PubSubAsyncConsumer of type {Type}", consumer.GetType());
+                return false;
+            }
+            finally
+            {
+                inboxSemaphore.Release();
+            }
+        }
+
+        #endregion
+
+        #region QueryResponseConsumer
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseConsumerAsync<Q,R, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreateQueryResponseConsumerSubscriptionAsync<Q, R>(consumer, channel, group, ignoreMessageHeader, cancellationToken);
+
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseConsumerAsync<Q, R, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreateQueryResponseConsumerSubscriptionAsync<Q, R>(
+                (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            );
+
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IQueryResponseConsumer<,>));
+            if (ifaceType==null)
+                throw new Exception("Unable to register consumer that does not implement the interface IQueryResponseConsumer<,>");
+            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseConsumerSubscriptionAsync))?
+                .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
+            return (ValueTask<bool>)methodinfo!.Invoke(this, [
+                (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            ])!;
+        }
+
+        private async ValueTask<bool> CreateQueryResponseConsumerSubscriptionAsync<Q, R>(IQueryResponseConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                consumerSubscriptions.Add(await ProduceSubscribeQueryResponseAsync<Q,R>(
+                    (message) => ValueTask.FromResult(consumer.MessageReceived(message)),
+                    (error) => consumer.ErrorRecieved(error),
+                    channel,
+                    group,
+                    ignoreMessageHeader,
+                    true,
+                    cancellationToken
+                ));
+                return true;
+            }
+            catch (Exception err)
+            {
+                logger?.LogError(err, "An error occured attempting to register a QueryResponseConsumer of type {Type}", consumer.GetType());
+                return false;
+            }
+            finally
+            {
+                inboxSemaphore.Release();
+            }
+        }
+
+        #endregion
+
+        #region QueryResponseAsyncConsumer
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(consumer, channel, group, ignoreMessageHeader, cancellationToken);
+
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync<Q, R, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+            => CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(
+                (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            );
+
+        ValueTask<bool> IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            var ifaceType = consumerType.GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IQueryResponseAsyncConsumer<,>));
+            if (ifaceType==null)
+                throw new Exception("Unable to register consumer that does not implement the interface IQueryResponseAsyncConsumer<,>");
+            var methodinfo = typeof(AConnection<CC>).GetMethod(nameof(AConnection<CC>.CreateQueryResponseAsyncConsumerSubscriptionAsync))?
+                .MakeGenericMethod(ifaceType.GetGenericArguments()[0], ifaceType.GetGenericArguments()[1]);
+            return (ValueTask<bool>)methodinfo!.Invoke(this, [
+                (serviceProvider==null ? Activator.CreateInstance(consumerType) : ActivatorUtilities.CreateInstance(serviceProvider,consumerType)),
+                channel,
+                group,
+                ignoreMessageHeader,
+                cancellationToken
+            ])!;
+        }
+
+        private async ValueTask<bool> CreateQueryResponseAsyncConsumerSubscriptionAsync<Q, R>(IQueryResponseAsyncConsumer<Q, R> consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        {
+            await inboxSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                consumerSubscriptions.Add(await ProduceSubscribeQueryResponseAsync<Q,R>(
+                    (message) =>consumer.MessageReceivedAsync(message),
+                    (error) => consumer.ErrorRecieved(error),
+                    channel,
+                    group,
+                    ignoreMessageHeader,
+                    true,
+                    cancellationToken
+                ));
+                return true;
+            }
+            catch (Exception err)
+            {
+                logger?.LogError(err, "An error occured attempting to register a QueryResponseAsyncConsumer of type {Type}", consumer.GetType());
+                return false;
+            }
+            finally
+            {
+                inboxSemaphore.Release();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 
 namespace MQContract.Connections
 {
-    internal abstract class AConnection<CC>(IMessageEncoder? defaultMessageEncoder = null,
+    internal abstract partial class AConnection<CC>(IMessageEncoder? defaultMessageEncoder = null,
         IMessageEncryptor? defaultMessageEncryptor = null,
         IServiceProvider? serviceProvider = null,
         ILogger? logger = null,
@@ -32,6 +32,7 @@ namespace MQContract.Connections
         private readonly Dictionary<Guid, TaskCompletionSource<ServiceQueryResult>> inboxResponses = [];
         private readonly Dictionary<string,IServiceSubscription> inboxSubscriptions = [];
         private IEnumerable<IMessageTypeFactory> typeFactories = [];
+        private readonly List<ISubscription> consumerSubscriptions = [];
         protected ILogger? Logger => logger;
         protected IDisposable? SetScope(string? messageID=null) => logger?.BeginScope<string>($"Connection[{indentifier}]{(messageID==null ? "" : $"|Message[{messageID}]")}");
 
@@ -232,7 +233,6 @@ namespace MQContract.Connections
             },
             errorReceived, channel, group, ignoreMessageHeader, true, cancellationToken);
         }
-
         protected abstract ValueTask<ISubscription> ProduceSubscribeQueryResponseAsync<Q, R>(Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken);
 
         ValueTask<ISubscription> IBaseContractConnection.SubscribeQueryAsyncResponseAsync<Q, R>(Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
@@ -526,6 +526,9 @@ namespace MQContract.Connections
                 var inboxSubscription = inboxSubscriptions[key];
                 await inboxSubscription.EndAsync();
             }
+            foreach(var consumerSubscription in consumerSubscriptions)
+                await consumerSubscription.EndAsync();
+            consumerSubscriptions.Clear();
             inboxSemaphore.Release();
             await CloseAsync();
         }
@@ -576,6 +579,9 @@ namespace MQContract.Connections
                 else if (inboxSubscription is IDisposable subDisposable)
                     subDisposable.Dispose();
             }
+            foreach (var consumerSubscription in consumerSubscriptions)
+                await consumerSubscription.EndAsync();
+            consumerSubscriptions.Clear();
             inboxSubscriptions.Clear();
             inboxSemaphore.Release();
             inboxSemaphore.Dispose();

--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -16,7 +16,9 @@ using System.Reflection;
 
 namespace MQContract.Connections
 {
+#pragma warning disable S3881 // "IDisposable" should be implemented correctly
     internal abstract partial class AConnection<CC>(IMessageEncoder? defaultMessageEncoder = null,
+#pragma warning restore S3881 // "IDisposable" should be implemented correctly
         IMessageEncryptor? defaultMessageEncryptor = null,
         IServiceProvider? serviceProvider = null,
         ILogger? logger = null,
@@ -352,7 +354,7 @@ namespace MQContract.Connections
             if (result.IsError)
             {
                 logger?.LogInformation("Inbox Query tranmission failed cleaning up resources");
-                await inboxSemaphore.WaitAsync();
+                await inboxSemaphore.WaitAsync(cancellationToken);
                 inboxResponses.Remove(messageID);
                 inboxSemaphore.Release();
                 throw new QuerySubmissionFailedException(result.Error!);
@@ -365,7 +367,7 @@ namespace MQContract.Connections
             {
                 if (!token.IsCancellationRequested)
                     await token.CancelAsync();
-                await inboxSemaphore.WaitAsync();
+                await inboxSemaphore.WaitAsync(cancellationToken);
                 inboxResponses.Remove(messageID);
                 inboxSemaphore.Release();
             }

--- a/Core/Defaults/BitConverterHelper.cs
+++ b/Core/Defaults/BitConverterHelper.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.Defaults
+﻿namespace MQContract.Defaults
 {
     internal static class BitConverterHelper
     {

--- a/Core/Defaults/BooleanEncoder.cs
+++ b/Core/Defaults/BooleanEncoder.cs
@@ -1,10 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/ByteEncoder.cs
+++ b/Core/Defaults/ByteEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/CharEncoder.cs
+++ b/Core/Defaults/CharEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/DecimalEncoder.cs
+++ b/Core/Defaults/DecimalEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/DoubleEncoder.cs
+++ b/Core/Defaults/DoubleEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/FloatEncoder.cs
+++ b/Core/Defaults/FloatEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/HalfEncoder.cs
+++ b/Core/Defaults/HalfEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/IntEncoder.cs
+++ b/Core/Defaults/IntEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/LongEncoder.cs
+++ b/Core/Defaults/LongEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/ShortEncoder.cs
+++ b/Core/Defaults/ShortEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/UIntEncoder.cs
+++ b/Core/Defaults/UIntEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/ULongEncoder.cs
+++ b/Core/Defaults/ULongEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Defaults/UShortEncoder.cs
+++ b/Core/Defaults/UShortEncoder.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Interfaces.Encoding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Defaults
 {

--- a/Core/Exceptions.cs
+++ b/Core/Exceptions.cs
@@ -101,12 +101,22 @@
     }
 
     /// <summary>
-    /// Thrown from a the ContractedConnection or the MappedConnection when there is no underlying service that supports the Ping call
+    /// Thrown from the ContractedConnection or the MappedConnection when there is no underlying service that supports the Ping call
     /// </summary>
     public class PingNotSupportedException : NotSupportedException
     {
         internal PingNotSupportedException()
             : base("The underlying service does not support Ping")
             {}
+    }
+
+    /// <summary>
+    /// Thrown from a ContractConnection when an attempt to Register a given consumer through Type is not valid because the type does not implement the appropriate interface
+    /// </summary>
+    public class InvalidConsumerType : NotSupportedException
+    {
+        internal InvalidConsumerType(Type consumerType,Type interfaceType)
+            : base($"Unable to register consumer of Type {consumerType.FullName} because it does not implement the interface {interfaceType.Name}") 
+        {}
     }
 }

--- a/Core/Readme.md
+++ b/Core/Readme.md
@@ -28,6 +28,7 @@
   - [Instance(serviceConnection,defaultMessageEncoder,defaultMessageEncryptor,serviceProvider,logger,channelMapper)](#M-MQContract-ContractConnection-Instance-MQContract-Interfaces-Service-IMessageServiceConnection,MQContract-Interfaces-Encoding-IMessageEncoder,MQContract-Interfaces-Encrypting-IMessageEncryptor,System-IServiceProvider,Microsoft-Extensions-Logging-ILogger,MQContract-ChannelMapper- 'MQContract.ContractConnection.Instance(MQContract.Interfaces.Service.IMessageServiceConnection,MQContract.Interfaces.Encoding.IMessageEncoder,MQContract.Interfaces.Encrypting.IMessageEncryptor,System.IServiceProvider,Microsoft.Extensions.Logging.ILogger,MQContract.ChannelMapper)')
   - [MappedServiceInstance(defaultMessageEncoder,defaultMessageEncryptor,serviceProvider,logger,channelMapper)](#M-MQContract-ContractConnection-MappedServiceInstance-MQContract-Interfaces-Encoding-IMessageEncoder,MQContract-Interfaces-Encrypting-IMessageEncryptor,System-IServiceProvider,Microsoft-Extensions-Logging-ILogger,MQContract-ChannelMapper- 'MQContract.ContractConnection.MappedServiceInstance(MQContract.Interfaces.Encoding.IMessageEncoder,MQContract.Interfaces.Encrypting.IMessageEncryptor,System.IServiceProvider,Microsoft.Extensions.Logging.ILogger,MQContract.ChannelMapper)')
   - [MultiServiceInstance(defaultMessageEncoder,defaultMessageEncryptor,serviceProvider,logger,channelMapper)](#M-MQContract-ContractConnection-MultiServiceInstance-MQContract-Interfaces-Encoding-IMessageEncoder,MQContract-Interfaces-Encrypting-IMessageEncryptor,System-IServiceProvider,Microsoft-Extensions-Logging-ILogger,MQContract-ChannelMapper- 'MQContract.ContractConnection.MultiServiceInstance(MQContract.Interfaces.Encoding.IMessageEncoder,MQContract.Interfaces.Encrypting.IMessageEncryptor,System.IServiceProvider,Microsoft.Extensions.Logging.ILogger,MQContract.ChannelMapper)')
+- [InvalidConsumerType](#T-MQContract-InvalidConsumerType 'MQContract.InvalidConsumerType')
 - [InvalidQueryResponseMessageReceivedException](#T-MQContract-InvalidQueryResponseMessageReceivedException 'MQContract.InvalidQueryResponseMessageReceivedException')
 - [MessageChannelNullException](#T-MQContract-MessageChannelNullException 'MQContract.MessageChannelNullException')
 - [MessageConversionException](#T-MQContract-MessageConversionException 'MQContract.MessageConversionException')
@@ -485,6 +486,17 @@ An instance of IMultiServiceContractConnection
 | channelMapper | [MQContract.ChannelMapper](#T-MQContract-ChannelMapper 'MQContract.ChannelMapper') | An instance of a ChannelMapper used to translate channels from one instance to another based on class channel attributes or supplied channels if necessary.
 For example, it might be necessary for a Nats.IO instance when you are trying to read from a stored message stream that is comprised of another channel or set of channels |
 
+<a name='T-MQContract-InvalidConsumerType'></a>
+## InvalidConsumerType `type`
+
+##### Namespace
+
+MQContract
+
+##### Summary
+
+Thrown from a ContractConnection when an attempt to Register a given consumer through Type is not valid because the type does not implement the appropriate interface
+
 <a name='T-MQContract-InvalidQueryResponseMessageReceivedException'></a>
 ## InvalidQueryResponseMessageReceivedException `type`
 
@@ -538,7 +550,7 @@ MQContract
 
 ##### Summary
 
-Thrown from a the ContractedConnection or the MappedConnection when there is no underlying service that supports the Ping call
+Thrown from the ContractedConnection or the MappedConnection when there is no underlying service that supports the Ping call
 
 <a name='T-MQContract-QueryExecutionFailedException'></a>
 ## QueryExecutionFailedException `type`

--- a/Samples/Messages/AnnouncementConsumer.cs
+++ b/Samples/Messages/AnnouncementConsumer.cs
@@ -1,0 +1,18 @@
+﻿using MQContract.Interfaces;
+using MQContract.Interfaces.Consumers;
+
+namespace Messages
+{
+    internal class AnnouncementConsumer : IPubSubConsumer<ArrivalAnnouncement>
+    {
+        void IBaseConsumer.ErrorRecieved(Exception error)
+        {
+            Console.WriteLine($"Announcement error: {error.Message}");
+        }
+
+        void IPubSubConsumer<ArrivalAnnouncement>.MessageReceived(IReceivedMessage<ArrivalAnnouncement> message)
+        {
+            Console.WriteLine($"Announcing the arrival of {message.Message.LastName}, {message.Message.FirstName} in member 2 of the group.. [{message.ID},{message.ReceivedTimestamp}]");
+        }
+    }
+}

--- a/Samples/Messages/SampleExecution.cs
+++ b/Samples/Messages/SampleExecution.cs
@@ -25,16 +25,7 @@ namespace Messages
                 cancellationToken: sourceCancel.Token
             );
 
-            var announcementSubscription2 = await contractConnection.SubscribeAsync<ArrivalAnnouncement>(
-                (announcement) =>
-                {
-                    Console.WriteLine($"Announcing the arrival of {announcement.Message.LastName}, {announcement.Message.FirstName} in member 2 of the group.. [{announcement.ID},{announcement.ReceivedTimestamp}]");
-                    return ValueTask.CompletedTask;
-                },
-                (error) => Console.WriteLine($"Announcement error: {error.Message}"),
-                group: "AnnouncementGroup",
-                cancellationToken: sourceCancel.Token
-            );
+            await contractConnection.RegisterPubSubConsumerAsync<ArrivalAnnouncement, AnnouncementConsumer>(group: "AnnouncementGroup", cancellationToken: sourceCancel.Token);
 
             var greetingSubscription = await contractConnection.SubscribeQueryResponseAsync<Greeting, string>(
                 (greeting) =>
@@ -63,7 +54,6 @@ namespace Messages
             {
                 await Task.WhenAll(
                     announcementSubscription1.EndAsync().AsTask(),
-                    announcementSubscription2.EndAsync().AsTask(),
                     greetingSubscription.EndAsync().AsTask(),
                     storedArrivalSubscription.EndAsync().AsTask()
                 ).ConfigureAwait(true);

--- a/Shared.props
+++ b/Shared.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<VersionPrefix>2.1.0</VersionPrefix>
+		<VersionPrefix>2.2.0</VersionPrefix>
 		<PackageProjectUrl>https://github.com/roger-castaldo/MQContract</PackageProjectUrl>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/roger-castaldo/MQContract</RepositoryUrl>


### PR DESCRIPTION
Adding in the concept of Consumers for both PubSub and QueryResponse that can be registered at the connection level and will clean themselves up once the ContractConnection is closed