### PR TITLE
patching for linked activity

### DIFF
--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -207,7 +207,7 @@ namespace MQContract.Connections
                 parent = new ActivityContext(current.TraceId, current.SpanId, ActivityTraceFlags.Recorded);
             using var activity = ActivitySource?.StartActivity(name, activityKind, parent,
                 links: Activity.Current!=null
-                ? [new ActivityLink(ActivityContext.Parse(Activity.Current!.ParentId!, Activity.Current!.TraceStateString))]
+                ? [new ActivityLink(ActivityContext.Parse((Activity.Current.Parent!=null ? Activity.Current!.ParentId! : Activity.Current.Id), Activity.Current!.TraceStateString))]
                 : []);
             if (serviceConnection!=null)
                 OtelHelper.AssignConnectionType(activity, serviceConnection!, connectionName);

--- a/Shared.props
+++ b/Shared.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<VersionPrefix>2.5.0</VersionPrefix>
+		<VersionPrefix>2.5.1</VersionPrefix>
 		<PackageProjectUrl>https://github.com/roger-castaldo/MQContract</PackageProjectUrl>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/roger-castaldo/MQContract</RepositoryUrl>


### PR DESCRIPTION
patching for a linked Activity when the Parent is null, found issue in testing with a live system that enabled other levels of Open Telemetry.