### PR TITLE
Added Message filtering

### DIFF
--- a/Abstractions/Abstractions.csproj
+++ b/Abstractions/Abstractions.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.19" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.21" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Abstractions/Enums.cs
+++ b/Abstractions/Enums.cs
@@ -1,0 +1,21 @@
+﻿namespace MQContract
+{
+    /// <summary>
+    /// These are the possible message filtering responses when supplying a message filtering action
+    /// </summary>
+    public enum MessageFilterResult
+    {
+        /// <summary>
+        /// Allow the message to continue through
+        /// </summary>
+        Allow,
+        /// <summary>
+        /// Do not allow the message to continue to the callback and Acknowledge it within the service
+        /// </summary>
+        DropAndAcknowledge,
+        /// <summary>
+        /// Do not allow the message to continue to the callback and do not Acknowledge it within the service
+        /// </summary>
+        DropAndDontAcknowledge
+    }
+}

--- a/Abstractions/Exceptions.cs
+++ b/Abstractions/Exceptions.cs
@@ -1,4 +1,6 @@
-﻿namespace MQContract
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MQContract
 {
     /// <summary>
     /// Thrown when an error occurs attempting to transmit a given message and is flagged if it is fatal or not

--- a/Abstractions/Interfaces/IBaseContractConnection.cs
+++ b/Abstractions/Interfaces/IBaseContractConnection.cs
@@ -17,10 +17,11 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <param name="cancellationToken">A cancellation token</param>
-        /// 
         /// <returns>A subscription instance that can be ended when desired</returns>
-        ValueTask<ISubscription> SubscribeAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+        ValueTask<ISubscription> SubscribeAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false,
+            MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to create a subscription into the underlying service Pub/Sub style and have the messages processed syncrhonously
         /// </summary>
@@ -30,10 +31,13 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// 
+        /// 
         /// <returns>A subscription instance that can be ended when desired</returns>
-        ValueTask<ISubscription> SubscribeAsync<T>(Action<IReceivedMessage<T>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+        ValueTask<ISubscription> SubscribeAsync<T>(Action<IReceivedMessage<T>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false,
+            MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to create a subscription into the underlying service Query/Reponse style and have the messages processed asynchronously
         /// </summary>
@@ -45,9 +49,9 @@ namespace MQContract.Interfaces
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
         /// <param name="cancellationToken">A cancellation token</param>
-        /// 
         /// <returns>A subscription instance that can be ended when desired</returns>
-        ValueTask<ISubscription> SubscribeQueryAsyncResponseAsync<Q, R>(Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+        ValueTask<ISubscription> SubscribeQueryAsyncResponseAsync<Q, R>(Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null,
+            bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to create a subscription into the underlying service Query/Reponse style and have the messages processed synchronously
         /// </summary>
@@ -59,9 +63,9 @@ namespace MQContract.Interfaces
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
         /// <param name="cancellationToken">A cancellation token</param>
-        /// 
         /// <returns>A subscription instance that can be ended when desired</returns>
-        ValueTask<ISubscription> SubscribeQueryResponseAsync<Q, R>(Func<IReceivedMessage<Q>, QueryResponseMessage<R>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
+        ValueTask<ISubscription> SubscribeQueryResponseAsync<Q, R>(Func<IReceivedMessage<Q>, QueryResponseMessage<R>> messageReceived, Action<Exception> errorReceived, string? channel = null, string? group = null,
+            bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to close off the contract connection and close it's underlying service connection
         /// </summary>

--- a/Abstractions/Interfaces/IConsumerContractConnection.cs
+++ b/Abstractions/Interfaces/IConsumerContractConnection.cs
@@ -1,4 +1,5 @@
 ﻿using MQContract.Interfaces.Consumers;
+using MQContract.Messages;
 using System.Reflection;
 
 namespace MQContract.Interfaces
@@ -24,9 +25,10 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
-        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <returns>A boolean indicating success or failure</returns>
-        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+        /// <param name="cancellationToken">A cancellation token</param>
+        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubConsumer<T>;
         /// <summary>
         /// Called to register a PubSubConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
@@ -36,9 +38,10 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
-        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <returns>A boolean indicating success or failure</returns>
-        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+        /// <param name="cancellationToken">A cancellation token</param>
+        ValueTask<bool> RegisterPubSubConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubConsumer<T>;
         /// <summary>
         /// Called to register a PubSubConsumer into the contract connection. 
@@ -47,8 +50,8 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
-        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A boolean indicating success or failure</returns>
+        /// <param name="cancellationToken">A cancellation token</param>
         ValueTask<bool> RegisterPubSubConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to register a PubSubAsyncConsumer into the contract connection 
@@ -59,9 +62,10 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
-        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <returns>A boolean indicating success or failure</returns>
-        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+        /// <param name="cancellationToken">A cancellation token</param>
+        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel = null, string? group = null, bool ignoreMessageHeader = false, MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubAsyncConsumer<T>;
         /// <summary>
         /// Called to register a PubSubAsyncConsumer into the contract connection.  This will create an instance of the TConsumer type that is requested and register it. 
@@ -71,9 +75,10 @@ namespace MQContract.Interfaces
         /// <param name="channel">Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class.</param>
         /// <param name="group">The subscription group if desired (typically used when multiple instances of the same system are running)</param>
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
-        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="messageFilters">Provides any filtering options for this subscription to filter out messages prior to action calls if desired</param>
         /// <returns>A boolean indicating success or failure</returns>
-        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken())
+        /// <param name="cancellationToken">A cancellation token</param>
+        ValueTask<bool> RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel = null, string? group = null, bool ignoreMessageHeader = false, MessageFilters<T>? messageFilters = null, CancellationToken cancellationToken = new CancellationToken())
             where TConsumer : IPubSubAsyncConsumer<T>;
         /// <summary>
         /// Called to register a PubSubAsyncConsumer into the contract connection. 
@@ -84,6 +89,7 @@ namespace MQContract.Interfaces
         /// <param name="ignoreMessageHeader">If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A boolean indicating success or failure</returns>
+        /// 
         ValueTask<bool> RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel = null, string? group = null, bool ignoreMessageHeader = false, CancellationToken cancellationToken = new CancellationToken());
         /// <summary>
         /// Called to register a QueryResponseConsumer into the contract connection 

--- a/Abstractions/Messages/MessageFilters.cs
+++ b/Abstractions/Messages/MessageFilters.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQContract.Messages
+{
+    /// <summary>
+    /// Houses a set of message filtering calls for a given type.  This particular record can be passed in to pubsub consumers/subscriptions
+    /// to implement some pre-callback message filtering when receiving messages
+    /// </summary>
+    /// <typeparam name="T">The type of message that the subscription and filter represents</typeparam>
+    /// <param name="HeaderFilter">A callback filter used to filter a message by headers.  This call is made prior to attempting to convert the message into the appropriate type.</param>
+    /// <param name="MessageFilter">A callback filter used to filter a message by the message and or headers.  This call is made after the attempt to convert the message into the approriate type.</param>
+    public record MessageFilters<T>(
+        Func<MessageHeader, ValueTask<MessageFilterResult>>? HeaderFilter = null,
+        Func<T, MessageHeader, ValueTask<MessageFilterResult>>? MessageFilter = null
+    );
+}

--- a/Abstractions/Readme.md
+++ b/Abstractions/Readme.md
@@ -33,8 +33,8 @@
 - [IBaseContractConnection](#T-MQContract-Interfaces-IBaseContractConnection 'MQContract.Interfaces.IBaseContractConnection')
   - [HealthCheck](#P-MQContract-Interfaces-IBaseContractConnection-HealthCheck 'MQContract.Interfaces.IBaseContractConnection.HealthCheck')
   - [CloseAsync()](#M-MQContract-Interfaces-IBaseContractConnection-CloseAsync 'MQContract.Interfaces.IBaseContractConnection.CloseAsync')
-  - [SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeAsync``1(System.Func{MQContract.Interfaces.IReceivedMessage{``0},System.Threading.Tasks.ValueTask},System.Action{System.Exception},System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
-  - [SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Action{MQContract-Interfaces-IReceivedMessage{``0}},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeAsync``1(System.Action{MQContract.Interfaces.IReceivedMessage{``0}},System.Action{System.Exception},System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask},System-Action{System-Exception},System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeAsync``1(System.Func{MQContract.Interfaces.IReceivedMessage{``0},System.Threading.Tasks.ValueTask},System.Action{System.Exception},System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
+  - [SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Action{MQContract-Interfaces-IReceivedMessage{``0}},System-Action{System-Exception},System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeAsync``1(System.Action{MQContract.Interfaces.IReceivedMessage{``0}},System.Action{System.Exception},System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
   - [SubscribeQueryAsyncResponseAsync\`\`2(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeQueryAsyncResponseAsync``2-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask{MQContract-Messages-QueryResponseMessage{``1}}},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeQueryAsyncResponseAsync``2(System.Func{MQContract.Interfaces.IReceivedMessage{``0},System.Threading.Tasks.ValueTask{MQContract.Messages.QueryResponseMessage{``1}}},System.Action{System.Exception},System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
   - [SubscribeQueryResponseAsync\`\`2(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IBaseContractConnection-SubscribeQueryResponseAsync``2-System-Func{MQContract-Interfaces-IReceivedMessage{``0},MQContract-Messages-QueryResponseMessage{``1}},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IBaseContractConnection.SubscribeQueryResponseAsync``2(System.Func{MQContract.Interfaces.IReceivedMessage{``0},MQContract.Messages.QueryResponseMessage{``1}},System.Action{System.Exception},System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
 - [IBeforeDecodeMiddleware](#T-MQContract-Interfaces-Middleware-IBeforeDecodeMiddleware 'MQContract.Interfaces.Middleware.IBeforeDecodeMiddleware')
@@ -48,11 +48,11 @@
 - [IConsumerContractConnection](#T-MQContract-Interfaces-IConsumerContractConnection 'MQContract.Interfaces.IConsumerContractConnection')
   - [AutoRegisterAllConsumersAsync(assembly,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-AutoRegisterAllConsumersAsync-System-Reflection-Assembly,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.AutoRegisterAllConsumersAsync(System.Reflection.Assembly,System.Threading.CancellationToken)')
   - [RegisterPubSubAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
-  - [RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(``1,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
-  - [RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(``1,System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
+  - [RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync``2(System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
   - [RegisterPubSubConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
-  - [RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(``1,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
-  - [RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
+  - [RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(``1,System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
+  - [RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,messageFilters,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterPubSubConsumerAsync``2(System.String,System.String,System.Boolean,MQContract.Messages.MessageFilters{``0},System.Threading.CancellationToken)')
   - [RegisterQueryResponseAsyncConsumerAsync(consumerType,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync-System-Type,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync(System.Type,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
   - [RegisterQueryResponseAsyncConsumerAsync\`\`3(consumer,channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-``2,System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync``3(``2,System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
   - [RegisterQueryResponseAsyncConsumerAsync\`\`3(channel,group,ignoreMessageHeader,cancellationToken)](#M-MQContract-Interfaces-IConsumerContractConnection-RegisterQueryResponseAsyncConsumerAsync``3-System-String,System-String,System-Boolean,System-Threading-CancellationToken- 'MQContract.Interfaces.IConsumerContractConnection.RegisterQueryResponseAsyncConsumerAsync``3(System.String,System.String,System.Boolean,System.Threading.CancellationToken)')
@@ -174,6 +174,14 @@
 - [MessageChannelAttribute](#T-MQContract-Attributes-MessageChannelAttribute 'MQContract.Attributes.MessageChannelAttribute')
   - [#ctor(name)](#M-MQContract-Attributes-MessageChannelAttribute-#ctor-System-String- 'MQContract.Attributes.MessageChannelAttribute.#ctor(System.String)')
   - [Name](#P-MQContract-Attributes-MessageChannelAttribute-Name 'MQContract.Attributes.MessageChannelAttribute.Name')
+- [MessageFilterResult](#T-MQContract-MessageFilterResult 'MQContract.MessageFilterResult')
+  - [Allow](#F-MQContract-MessageFilterResult-Allow 'MQContract.MessageFilterResult.Allow')
+  - [DropAndAcknowledge](#F-MQContract-MessageFilterResult-DropAndAcknowledge 'MQContract.MessageFilterResult.DropAndAcknowledge')
+  - [DropAndDontAcknowledge](#F-MQContract-MessageFilterResult-DropAndDontAcknowledge 'MQContract.MessageFilterResult.DropAndDontAcknowledge')
+- [MessageFilters\`1](#T-MQContract-Messages-MessageFilters`1 'MQContract.Messages.MessageFilters`1')
+  - [#ctor(HeaderFilter,MessageFilter)](#M-MQContract-Messages-MessageFilters`1-#ctor-System-Func{MQContract-Messages-MessageHeader,System-Threading-Tasks-ValueTask{MQContract-MessageFilterResult}},System-Func{`0,MQContract-Messages-MessageHeader,System-Threading-Tasks-ValueTask{MQContract-MessageFilterResult}}- 'MQContract.Messages.MessageFilters`1.#ctor(System.Func{MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}},System.Func{`0,MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}})')
+  - [HeaderFilter](#P-MQContract-Messages-MessageFilters`1-HeaderFilter 'MQContract.Messages.MessageFilters`1.HeaderFilter')
+  - [MessageFilter](#P-MQContract-Messages-MessageFilters`1-MessageFilter 'MQContract.Messages.MessageFilters`1.MessageFilter')
 - [MessageHeader](#T-MQContract-Messages-MessageHeader 'MQContract.Messages.MessageHeader')
   - [#ctor(data)](#M-MQContract-Messages-MessageHeader-#ctor-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}}- 'MQContract.Messages.MessageHeader.#ctor(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}})')
   - [#ctor(headers)](#M-MQContract-Messages-MessageHeader-#ctor-System-Collections-Generic-Dictionary{System-String,System-String}- 'MQContract.Messages.MessageHeader.#ctor(System.Collections.Generic.Dictionary{System.String,System.String})')
@@ -634,8 +642,8 @@ A task for the closure of the connection
 
 This method has no parameters.
 
-<a name='M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Func{MQContract-Interfaces-IReceivedMessage{``0},System-Threading-Tasks-ValueTask},System-Action{System-Exception},System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -654,6 +662,7 @@ A subscription instance that can be ended when desired
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -662,8 +671,8 @@ A subscription instance that can be ended when desired
 | ---- | ----------- |
 | T | The type of message to listen for |
 
-<a name='M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Action{MQContract-Interfaces-IReceivedMessage{``0}},System-Action{System-Exception},System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IBaseContractConnection-SubscribeAsync``1-System-Action{MQContract-Interfaces-IReceivedMessage{``0}},System-Action{System-Exception},System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### SubscribeAsync\`\`1(messageReceived,errorReceived,channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -682,6 +691,7 @@ A subscription instance that can be ended when desired
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -928,8 +938,8 @@ A boolean indicating success or failure
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
-<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-``1,System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### RegisterPubSubAsyncConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -947,6 +957,7 @@ A boolean indicating success or failure
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -956,8 +967,8 @@ A boolean indicating success or failure
 | T | The Message type |
 | TConsumer | The type that implements PubSubAsyncConsumer<T> |
 
-<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubAsyncConsumerAsync``2-System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### RegisterPubSubAsyncConsumerAsync\`\`2(channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -974,6 +985,7 @@ A boolean indicating success or failure
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -1004,8 +1016,8 @@ A boolean indicating success or failure
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
-<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-``1,System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### RegisterPubSubConsumerAsync\`\`2(consumer,channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -1023,6 +1035,7 @@ A boolean indicating success or failure
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -1032,8 +1045,8 @@ A boolean indicating success or failure
 | T | The Message type |
 | TConsumer | The type that implements IPubSubConsumer<T> |
 
-<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,System-Threading-CancellationToken-'></a>
-### RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,cancellationToken) `method`
+<a name='M-MQContract-Interfaces-IConsumerContractConnection-RegisterPubSubConsumerAsync``2-System-String,System-String,System-Boolean,MQContract-Messages-MessageFilters{``0},System-Threading-CancellationToken-'></a>
+### RegisterPubSubConsumerAsync\`\`2(channel,group,ignoreMessageHeader,messageFilters,cancellationToken) `method`
 
 ##### Summary
 
@@ -1050,6 +1063,7 @@ A boolean indicating success or failure
 | channel | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Specifies the message channel to use.  The prefered method is using the MessageChannelAttribute on the Message class. |
 | group | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The subscription group if desired (typically used when multiple instances of the same system are running) |
 | ignoreMessageHeader | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | If true, the message type specified will be ignored and it will automatically attempt to convert the underlying message to the given class |
+| messageFilters | [MQContract.Messages.MessageFilters{\`\`0}](#T-MQContract-Messages-MessageFilters{``0} 'MQContract.Messages.MessageFilters{``0}') | Provides any filtering options for this subscription to filter out messages prior to action calls if desired |
 | cancellationToken | [System.Threading.CancellationToken](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Threading.CancellationToken 'System.Threading.CancellationToken') | A cancellation token |
 
 ##### Generic Types
@@ -3048,6 +3062,97 @@ be specified, either using the attribute or by specifying in the input.
 ##### Summary
 
 The name of the channel specified
+
+<a name='T-MQContract-MessageFilterResult'></a>
+## MessageFilterResult `type`
+
+##### Namespace
+
+MQContract
+
+##### Summary
+
+These are the possible message filtering responses when supplying a message filtering action
+
+<a name='F-MQContract-MessageFilterResult-Allow'></a>
+### Allow `constants`
+
+##### Summary
+
+Allow the message to continue through
+
+<a name='F-MQContract-MessageFilterResult-DropAndAcknowledge'></a>
+### DropAndAcknowledge `constants`
+
+##### Summary
+
+Do not allow the message to continue to the callback and Acknowledge it within the service
+
+<a name='F-MQContract-MessageFilterResult-DropAndDontAcknowledge'></a>
+### DropAndDontAcknowledge `constants`
+
+##### Summary
+
+Do not allow the message to continue to the callback and do not Acknowledge it within the service
+
+<a name='T-MQContract-Messages-MessageFilters`1'></a>
+## MessageFilters\`1 `type`
+
+##### Namespace
+
+MQContract.Messages
+
+##### Summary
+
+Houses a set of message filtering calls for a given type.  This particular record can be passed in to pubsub consumers/subscriptions
+to implement some pre-callback message filtering when receiving messages
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| HeaderFilter | [T:MQContract.Messages.MessageFilters\`1](#T-T-MQContract-Messages-MessageFilters`1 'T:MQContract.Messages.MessageFilters`1') | A callback filter used to filter a message by headers.  This call is made prior to attempting to convert the message into the appropriate type. |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The type of message that the subscription and filter represents |
+
+<a name='M-MQContract-Messages-MessageFilters`1-#ctor-System-Func{MQContract-Messages-MessageHeader,System-Threading-Tasks-ValueTask{MQContract-MessageFilterResult}},System-Func{`0,MQContract-Messages-MessageHeader,System-Threading-Tasks-ValueTask{MQContract-MessageFilterResult}}-'></a>
+### #ctor(HeaderFilter,MessageFilter) `constructor`
+
+##### Summary
+
+Houses a set of message filtering calls for a given type.  This particular record can be passed in to pubsub consumers/subscriptions
+to implement some pre-callback message filtering when receiving messages
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| HeaderFilter | [System.Func{MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}}') | A callback filter used to filter a message by headers.  This call is made prior to attempting to convert the message into the appropriate type. |
+| MessageFilter | [System.Func{\`0,MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{`0,MQContract.Messages.MessageHeader,System.Threading.Tasks.ValueTask{MQContract.MessageFilterResult}}') | A callback filter used to filter a message by the message and or headers.  This call is made after the attempt to convert the message into the approriate type. |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The type of message that the subscription and filter represents |
+
+<a name='P-MQContract-Messages-MessageFilters`1-HeaderFilter'></a>
+### HeaderFilter `property`
+
+##### Summary
+
+A callback filter used to filter a message by headers.  This call is made prior to attempting to convert the message into the appropriate type.
+
+<a name='P-MQContract-Messages-MessageFilters`1-MessageFilter'></a>
+### MessageFilter `property`
+
+##### Summary
+
+A callback filter used to filter a message by the message and or headers.  This call is made after the attempt to convert the message into the approriate type.
 
 <a name='T-MQContract-Messages-MessageHeader'></a>
 ## MessageHeader `type`

--- a/AutomatedTesting/AutomatedTesting.csproj
+++ b/AutomatedTesting/AutomatedTesting.csproj
@@ -14,8 +14,8 @@
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
 	  <PackageReference Include="Moq" Version="4.20.72" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="3.11.0" />
-	  <PackageReference Include="MSTest.TestFramework" Version="3.11.0" />
+	  <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
+	  <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
 	  <PackageReference Include="coverlet.collector" Version="6.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
@@ -1,11 +1,13 @@
 ﻿using AutomatedTesting.Consumers;
 using AutomatedTesting.Messages;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Moq;
 using MQContract;
 using MQContract.Attributes;
 using MQContract.Interfaces;
 using MQContract.Interfaces.Consumers;
 using MQContract.Interfaces.Service;
+using MQContract.Messages;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -534,6 +536,106 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Verify
             serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
+
+        [TestMethod]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        public async Task TestRegisterConsumerWithFiltering(string headerValue, string checkValue, string messageHeaderValue, string messageHeaderCheckValue,
+            string messageValue, string messageCheckValue, bool acknowledgeDrop)
+        {
+            #region Arrange
+            var headerKey = "testHeader";
+            var messageHeaderKey = "testMessageHeader";
+            var acknowledged = false;
+
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var message = new BasicMessage(messageValue);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubAsyncConsumerAsync<BasicMessage, BasicMessageAsyncConsumer>(messageFilters: new(
+                HeaderFilter: (header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[headerKey], checkValue), acknowledgeDrop) switch
+                    {
+                        (true, _) => MessageFilterResult.Allow,
+                        (false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, true) => MessageFilterResult.DropAndAcknowledge
+                    }),
+                MessageFilter: (serviceMessage, header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[messageHeaderKey], messageHeaderCheckValue), Equals(serviceMessage.Name, messageCheckValue), acknowledgeDrop) switch
+                    {
+                        (true, true, _) => MessageFilterResult.Allow,
+                        (false, _, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, _, true) => MessageFilterResult.DropAndAcknowledge,
+                        (_, false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (_, false, true) => MessageFilterResult.DropAndAcknowledge,
+                    })
+            ));
+            var result = await contractConnection.PublishAsync<BasicMessage>(message, messageHeader: new([
+                new KeyValuePair<string,string>(headerKey,headerValue),
+                new KeyValuePair<string,string>(messageHeaderKey,messageHeaderValue)
+            ]));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
+            {
+                Assert.IsTrue(await Helper.WaitForCount(BasicMessageAsyncConsumer.Messages, 1, TimeSpan.FromMinutes(1)));
+                Assert.AreEqual(serviceMessages[0].ID, BasicMessageAsyncConsumer.Messages[0].ID);
+                Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), BasicMessageAsyncConsumer.Messages[0].Headers.Keys.Count());
+                Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, BasicMessageAsyncConsumer.Messages[0].ReceivedTimestamp);
+                Assert.AreEqual(message, BasicMessageAsyncConsumer.Messages[0].Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, BasicMessageAsyncConsumer.Messages.Count);
+            }
+            Assert.AreEqual(acknowledgeDrop, acknowledged);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
             #endregion
         }

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
@@ -508,5 +508,105 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
             #endregion
         }
+
+        [TestMethod]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        public async Task TestRegisterConsumerWithFiltering(string headerValue, string checkValue, string messageHeaderValue, string messageHeaderCheckValue,
+            string messageValue, string messageCheckValue, bool acknowledgeDrop)
+        {
+            #region Arrange
+            var headerKey = "testHeader";
+            var messageHeaderKey = "testMessageHeader";
+            var acknowledged = false;
+
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceSubscription.Setup(x => x.EndAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var message = new BasicMessage(messageValue);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var registrationResult = await contractConnection.RegisterPubSubConsumerAsync<BasicMessage, BasicMessageConsumer>(messageFilters: new(
+                HeaderFilter: (header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[headerKey], checkValue), acknowledgeDrop) switch
+                    {
+                        (true, _) => MessageFilterResult.Allow,
+                        (false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, true) => MessageFilterResult.DropAndAcknowledge
+                    }),
+                MessageFilter: (serviceMessage, header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[messageHeaderKey], messageHeaderCheckValue), Equals(serviceMessage.Name, messageCheckValue), acknowledgeDrop) switch
+                    {
+                        (true, true, _) => MessageFilterResult.Allow,
+                        (false, _, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, _, true) => MessageFilterResult.DropAndAcknowledge,
+                        (_, false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (_, false, true) => MessageFilterResult.DropAndAcknowledge,
+                    })
+            ));
+            var result = await contractConnection.PublishAsync<BasicMessage>(message, messageHeader: new([
+                new KeyValuePair<string,string>(headerKey,headerValue),
+                new KeyValuePair<string,string>(messageHeaderKey,messageHeaderValue)
+            ]));
+            #endregion
+
+            #region Assert
+            Assert.IsTrue(registrationResult);
+            await contractConnection.CloseAsync();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
+            {
+                Assert.IsTrue(await Helper.WaitForCount(BasicMessageConsumer.Messages, 1, TimeSpan.FromMinutes(1)));
+                Assert.AreEqual(serviceMessages[0].ID, BasicMessageConsumer.Messages[0].ID);
+                Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), BasicMessageConsumer.Messages[0].Headers.Keys.Count());
+                Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, BasicMessageConsumer.Messages[0].ReceivedTimestamp);
+                Assert.AreEqual(message, BasicMessageConsumer.Messages[0].Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, BasicMessageConsumer.Messages.Count);
+            }
+            Assert.AreEqual(acknowledgeDrop, acknowledged);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceSubscription.Verify(x => x.EndAsync(), Times.Once);
+            #endregion
+        }
     }
 }

--- a/AutomatedTesting/ConnectionTests/MappedService/HealthCheckTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/HealthCheckTests.cs
@@ -51,7 +51,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
         public async Task TestPingExceptionUnhealthyCheck()
         {
             #region Arrange
-            var error = new Exception("Ping failed");
+            var error = new PingFailedException("Ping failed");
 
             var serviceConnection = new Mock<IPingableMessageServiceConnection>();
             serviceConnection.Setup(x => x.PingAsync())

--- a/AutomatedTesting/ConnectionTests/MappedService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/SubscribeTests.cs
@@ -1127,6 +1127,108 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }
+
+        [TestMethod]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        public async Task TestSubscribeAsyncWithFiltering(string headerValue, string checkValue, string messageHeaderValue, string messageHeaderCheckValue,
+            string messageValue, string messageCheckValue, bool acknowledgeDrop)
+        {
+            #region Arrange
+            var headerKey = "testHeader";
+            var messageHeaderKey = "testMessageHeader";
+            var acknowledged = false;
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var message = new BasicMessage(messageValue);
+
+            var contractConnection = ContractConnection.MappedServiceInstance().RegisterServiceConnection((props) => true, ServiceName, serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var messages = new List<IReceivedMessage<BasicMessage>>();
+            var subscription = await contractConnection.SubscribeAsync<BasicMessage>((msg) =>
+            {
+                messages.Add(msg);
+                return ValueTask.CompletedTask;
+            }, (error) => { },
+            messageFilters: new(
+                HeaderFilter: (header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[headerKey], checkValue), acknowledgeDrop) switch
+                    {
+                        (true, _) => MessageFilterResult.Allow,
+                        (false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, true) => MessageFilterResult.DropAndAcknowledge
+                    }),
+                MessageFilter: (serviceMessage, header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[messageHeaderKey], messageHeaderCheckValue), Equals(serviceMessage.Name, messageCheckValue), acknowledgeDrop) switch
+                    {
+                        (true, true, _) => MessageFilterResult.Allow,
+                        (false, _, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, _, true) => MessageFilterResult.DropAndAcknowledge,
+                        (_, false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (_, false, true) => MessageFilterResult.DropAndAcknowledge,
+                    })
+            ));
+            var result = await contractConnection.PublishAsync<BasicMessage>(message, messageHeader: new([
+                new KeyValuePair<string,string>(headerKey,headerValue),
+                new KeyValuePair<string,string>(messageHeaderKey,messageHeaderValue)
+            ]));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(subscription);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
+            {
+                Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+                Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+                Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+                Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+                Assert.AreEqual(message, messages[0].Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, messages.Count);
+            }
+            Assert.AreEqual(acknowledgeDrop, acknowledged);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
     }
 }
 

--- a/AutomatedTesting/ConnectionTests/MiddleWareTests.cs
+++ b/AutomatedTesting/ConnectionTests/MiddleWareTests.cs
@@ -200,7 +200,7 @@ namespace AutomatedTesting.ContractConnectionTests
                 .ReturnsAsync(transmissionResult);
 
             var contractConnection = ContractConnection.Instance(serviceConnection.Object)
-                .RegisterMiddleware(()=>new ChannelChangeMiddleware());
+                .RegisterMiddleware(()=>((IMiddleware)new ChannelChangeMiddleware()));
             #endregion
 
             #region Act

--- a/AutomatedTesting/ConnectionTests/MultiService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/SubscribeTests.cs
@@ -1070,6 +1070,109 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }
+
+        [TestMethod]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        public async Task TestSubscribeAsyncWithFiltering(string headerValue, string checkValue, string messageHeaderValue, string messageHeaderCheckValue,
+           string messageValue, string messageCheckValue, bool acknowledgeDrop)
+        {
+            #region Arrange
+            var headerKey = "testHeader";
+            var messageHeaderKey = "testMessageHeader";
+            var acknowledged = false;
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var message = new BasicMessage(messageValue);
+
+            var contractConnection = ContractConnection.MultiServiceInstance()
+                .RegisterServiceConnection(ServiceName, serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var messages = new List<IReceivedMessage<BasicMessage>>();
+            var subscription = await contractConnection.SubscribeAsync<BasicMessage>((msg) =>
+            {
+                messages.Add(msg);
+                return ValueTask.CompletedTask;
+            }, (error) => { },
+            messageFilters: new(
+                HeaderFilter: (header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[headerKey], checkValue), acknowledgeDrop) switch
+                    {
+                        (true, _) => MessageFilterResult.Allow,
+                        (false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, true) => MessageFilterResult.DropAndAcknowledge
+                    }),
+                MessageFilter: (serviceMessage, header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[messageHeaderKey], messageHeaderCheckValue), Equals(serviceMessage.Name, messageCheckValue), acknowledgeDrop) switch
+                    {
+                        (true, true, _) => MessageFilterResult.Allow,
+                        (false, _, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, _, true) => MessageFilterResult.DropAndAcknowledge,
+                        (_, false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (_, false, true) => MessageFilterResult.DropAndAcknowledge,
+                    })
+            ));
+            var result = await contractConnection.PublishAsync<BasicMessage>(message, messageHeader: new([
+                new KeyValuePair<string,string>(headerKey,headerValue),
+                new KeyValuePair<string,string>(messageHeaderKey,messageHeaderValue)
+            ]));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(subscription);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
+            {
+                Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+                Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+                Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+                Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+                Assert.AreEqual(message, messages[0].Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, messages.Count);
+            }
+            Assert.AreEqual(acknowledgeDrop, acknowledged);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
     }
 }
 

--- a/AutomatedTesting/ConnectionTests/SingleService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/SubscribeTests.cs
@@ -1048,6 +1048,108 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
             #endregion
         }
+
+        [TestMethod]
+        [DataRow("headerValue","differentHeaderValue","messageHeaderValue","messageHeaderValue","messageValue","messageValue",true)]
+        [DataRow("headerValue", "differentHeaderValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "differentMessageHeaderValue", "messageValue", "messageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", true)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "differentMessageValue", false)]
+        [DataRow("headerValue", "headerValue", "messageHeaderValue", "messageHeaderValue", "messageValue", "messageValue", true)]
+        public async Task TestSubscribeAsyncWithFiltering(string headerValue,string checkValue, string messageHeaderValue,string messageHeaderCheckValue,
+            string messageValue,string messageCheckValue,bool acknowledgeDrop)
+        {
+            #region Arrange
+            var headerKey = "testHeader";
+            var messageHeaderKey = "testMessageHeader";
+            var acknowledged = false;
+
+            var transmissionResult = new TransmissionResult(Guid.NewGuid().ToString());
+            var serviceSubscription = new Mock<IServiceSubscription>();
+            var serviceConnection = new Mock<IMessageServiceConnection>();
+
+            var actions = new List<Action<ReceivedServiceMessage>>();
+            var serviceMessages = new List<ReceivedServiceMessage>();
+
+            serviceConnection.Setup(x => x.SubscribeAsync(Capture.In(actions), It.IsAny<Action<Exception>>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serviceSubscription.Object);
+            serviceConnection.Setup(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((ServiceMessage message, CancellationToken cancellationToken) =>
+                {
+                    var rmessage = Helper.ProduceReceivedServiceMessage(message, acknowledge: () =>
+                    {
+                        acknowledged=true;
+                        return ValueTask.CompletedTask;
+                    });
+                    serviceMessages.Add(rmessage);
+                    foreach (var act in actions)
+                        act(rmessage);
+                    return ValueTask.FromResult(transmissionResult);
+                });
+
+            var message = new BasicMessage(messageValue);
+
+            var contractConnection = ContractConnection.Instance(serviceConnection.Object);
+            #endregion
+
+            #region Act
+            var messages = new List<IReceivedMessage<BasicMessage>>();
+            var subscription = await contractConnection.SubscribeAsync<BasicMessage>((msg) =>
+            {
+                messages.Add(msg);
+                return ValueTask.CompletedTask;
+            }, (error) => { },
+            messageFilters: new(
+                HeaderFilter: (header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[headerKey], checkValue), acknowledgeDrop) switch
+                    {
+                        (true, _) => MessageFilterResult.Allow,
+                        (false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, true) => MessageFilterResult.DropAndAcknowledge
+                    }),
+                MessageFilter: (serviceMessage,header) =>
+                    ValueTask.FromResult<MessageFilterResult>((Equals(header[messageHeaderKey], messageHeaderCheckValue), Equals(serviceMessage.Name,messageCheckValue), acknowledgeDrop) switch
+                    {
+                        (true,true, _) => MessageFilterResult.Allow,
+                        (false, _, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (false, _, true) => MessageFilterResult.DropAndAcknowledge,
+                        (_, false, false) => MessageFilterResult.DropAndDontAcknowledge,
+                        (_, false, true) => MessageFilterResult.DropAndAcknowledge,
+                    })
+            ));
+            var result = await contractConnection.PublishAsync<BasicMessage>(message, messageHeader: new([
+                new KeyValuePair<string,string>(headerKey,headerValue),
+                new KeyValuePair<string,string>(messageHeaderKey,messageHeaderValue)
+            ]));
+            #endregion
+
+            #region Assert
+            Assert.IsNotNull(subscription);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, actions.Count);
+            Assert.AreEqual(1, serviceMessages.Count);
+            if (Equals(headerValue, checkValue) && Equals(messageHeaderValue,messageHeaderCheckValue) && Equals(messageValue,messageCheckValue))
+            {
+                Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
+                Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
+                Assert.AreEqual(serviceMessages[0].Header.Keys.Count(), messages[0].Headers.Keys.Count());
+                Assert.AreEqual(serviceMessages[0].ReceivedTimestamp, messages[0].ReceivedTimestamp);
+                Assert.AreEqual(message, messages[0].Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, messages.Count);
+            }
+            Assert.AreEqual(acknowledgeDrop, acknowledged);
+            #endregion
+
+            #region Verify
+            serviceConnection.Verify(x => x.SubscribeAsync(It.IsAny<Action<ReceivedServiceMessage>>(), It.IsAny<Action<Exception>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            serviceConnection.Verify(x => x.PublishAsync(It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            #endregion
+        }
     }
 }
 

--- a/AutomatedTesting/Consumers/BasicMessageAsyncConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicMessageAsyncConsumer.cs
@@ -9,10 +9,22 @@ namespace AutomatedTesting.Consumers
     [ConsumerGroup("AsyncBasicMessageGroup")]
     internal class BasicMessageAsyncConsumer : IPubSubAsyncConsumer<BasicMessage>
     {
+        private static readonly List<IReceivedMessage<BasicMessage>> messages = [];
+
+        public static List<IReceivedMessage<BasicMessage>> Messages => messages;
+
+        public BasicMessageAsyncConsumer()
+        {
+            messages.Clear();
+        }
+
         void IBaseConsumer.ErrorRecieved(Exception error)
         { }
 
         ValueTask IPubSubAsyncConsumer<BasicMessage>.MessageReceivedAsync(IReceivedMessage<BasicMessage> message)
-        => ValueTask.CompletedTask;
+        {
+            messages.Add(message);
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/AutomatedTesting/Consumers/BasicMessageConsumer.cs
+++ b/AutomatedTesting/Consumers/BasicMessageConsumer.cs
@@ -6,10 +6,19 @@ namespace AutomatedTesting.Consumers
 {
     internal class BasicMessageConsumer : IPubSubConsumer<BasicMessage>
     {
+        private static readonly List<IReceivedMessage<BasicMessage>> messages = [];
+
+        public static List<IReceivedMessage<BasicMessage>> Messages => messages;
+
+        public BasicMessageConsumer()
+        {
+            messages.Clear();
+        }
+
         void IBaseConsumer.ErrorRecieved(Exception error)
         { }
 
         void IPubSubConsumer<BasicMessage>.MessageReceived(IReceivedMessage<BasicMessage> message)
-        { }
+            => messages.Add(message);
     }
 }

--- a/BenchMark/BenchMark.csproj
+++ b/BenchMark/BenchMark.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BenchMark/PublishBenchmarks/Publishing.cs
+++ b/BenchMark/PublishBenchmarks/Publishing.cs
@@ -12,10 +12,10 @@ namespace BenchMark.PublishBenchmarks
     {
         public const string ChannelName = "sample";
         private const string MessageContent = "The quick brown fox";
-        private IMessageServiceConnection serviceConnection;
-        private IContractConnection contractConnection;
-        private Announcement announcement;
-        private EncodedAnnouncement encodedAnnouncement;
+        private IMessageServiceConnection? serviceConnection;
+        private IContractConnection? contractConnection;
+        private Announcement? announcement;
+        private EncodedAnnouncement? encodedAnnouncement;
 
         [GlobalSetup]
         public void Setup()
@@ -29,25 +29,25 @@ namespace BenchMark.PublishBenchmarks
         [Benchmark(Baseline = true)]
         public async Task PublishDirectlyToConnection()
         {
-            _ = await serviceConnection.PublishAsync(new(Guid.NewGuid().ToString(), "sample", ChannelName, new([]), ASCIIEncoding.ASCII.GetBytes(MessageContent)));
+            _ = await serviceConnection!.PublishAsync(new(Guid.NewGuid().ToString(), "sample", ChannelName, new([]), ASCIIEncoding.ASCII.GetBytes(MessageContent)));
         }
 
         [Benchmark]
         public async Task PublishBasicEncodedMessage()
         {
-            _ = await contractConnection.PublishAsync<string>(MessageContent, channel: ChannelName);
+            _ = await contractConnection!.PublishAsync<string>(MessageContent, channel: ChannelName);
         }
 
         [Benchmark]
         public async Task PublishDefaultEncodedMessage()
         {
-            _ = await contractConnection.PublishAsync<Announcement>(announcement, channel: ChannelName);
+            _ = await contractConnection!.PublishAsync<Announcement>(announcement!, channel: ChannelName);
         }
 
         [Benchmark]
         public async Task PublishCustomEncodedMessage()
         {
-            _ = await contractConnection.PublishAsync<EncodedAnnouncement>(encodedAnnouncement, channel: ChannelName);
+            _ = await contractConnection!.PublishAsync<EncodedAnnouncement>(encodedAnnouncement!, channel: ChannelName);
         }
     }
 }

--- a/BenchMark/PublishBenchmarks/PublishingWithMiddleware.cs
+++ b/BenchMark/PublishBenchmarks/PublishingWithMiddleware.cs
@@ -9,18 +9,16 @@ namespace BenchMark.PublishBenchmarks
     public class PublishingWithMiddleware
     {
         [Params("", "Metrics", "OTEL")]
-        public string Middleware { get; set; }
+        public string Middleware { get; set; } = string.Empty;
 
         public const string ChannelName = "sample";
         private const string MessageContent = "The quick brown fox";
-        private IMessageServiceConnection serviceConnection;
-        private IContractedConnection contractConnection;
+        private IContractedConnection? contractConnection;
 
         [GlobalSetup]
         public void Setup()
         {
-            serviceConnection = new FakePublishConnection();
-            contractConnection = ContractConnection.Instance(serviceConnection);
+            contractConnection = ContractConnection.Instance(new FakePublishConnection());
             switch (Middleware)
             {
                 case "Metrics":
@@ -37,7 +35,7 @@ namespace BenchMark.PublishBenchmarks
         [Benchmark]
         public async Task PublishBasicEncodedMessage()
         {
-            _ = await contractConnection.PublishAsync<string>(MessageContent, channel: ChannelName);
+            _ = await contractConnection!.PublishAsync<string>(MessageContent, channel: ChannelName);
         }
     }
 }

--- a/Core/Connections/AConnection.Consumers.cs
+++ b/Core/Connections/AConnection.Consumers.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using MQContract.Attributes;
 using MQContract.Interfaces;
 using MQContract.Interfaces.Consumers;
+using MQContract.Messages;
 using MQContract.Middleware;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -126,7 +127,7 @@ namespace MQContract.Connections
         IHealthCheck? IBaseContractConnection.HealthCheck => healthCheck??=ProduceConnectionHealthCheck();
 
         #region PubSubConsumer
-        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
             => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) =>
                     {
@@ -138,6 +139,7 @@ namespace MQContract.Connections
                     channel,
                     group,
                     ignoreMessageHeader,
+                    messageFilters,
                     true,
                     cancellationToken
                 ),
@@ -149,17 +151,18 @@ namespace MQContract.Connections
                 cancellationToken
             );
 
-        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
             => ((IConsumerContractConnection)this).RegisterPubSubConsumerAsync<T, TConsumer>(
                 (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
                 channel,
                 group,
                 ignoreMessageHeader,
-                cancellationToken
+                messageFilters,
+                cancellationToken: cancellationToken
             );
 
         private static readonly MethodInfo RegisterPubSubConsumerMethod = typeof(IConsumerContractConnection).GetMethods()
-            .First(method => Equals(method.Name, "RegisterPubSubConsumerAsync") && method.GetGenericArguments().Length==2 && method.GetParameters().Length==5);
+            .First(method => Equals(method.Name, "RegisterPubSubConsumerAsync") && method.GetGenericArguments().Length==2 && method.GetParameters().Length==6);
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IPubSubConsumer<>));
@@ -169,6 +172,7 @@ namespace MQContract.Connections
                 channel,
                 group,
                 ignoreMessageHeader,
+                null,
                 cancellationToken
             ])!;
         }
@@ -176,7 +180,7 @@ namespace MQContract.Connections
         #endregion
 
         #region PubSubAsyncConsumer
-        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(TConsumer consumer, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
             => RegisterSubscription((channel, group, ignoreMessageHeader) => CreateSubscriptionAsync<T>(
                     (message) =>
                     {
@@ -187,6 +191,7 @@ namespace MQContract.Connections
                     channel,
                     group,
                     ignoreMessageHeader,
+                    messageFilters,
                     true,
                     cancellationToken
                 ),
@@ -198,17 +203,18 @@ namespace MQContract.Connections
                 cancellationToken
             );
 
-        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync<T, TConsumer>(string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
             => ((IConsumerContractConnection)this).RegisterPubSubAsyncConsumerAsync<T, TConsumer>(
                 (serviceProvider==null ? Activator.CreateInstance<TConsumer>() : ActivatorUtilities.CreateInstance<TConsumer>(serviceProvider)),
                 channel,
                 group,
                 ignoreMessageHeader,
-                cancellationToken
+                messageFilters,
+                cancellationToken: cancellationToken
             );
 
         private static readonly MethodInfo RegisterPubSubAsyncConsumerMethod = typeof(IConsumerContractConnection).GetMethods()
-            .First(method => Equals(method.Name, "RegisterPubSubAsyncConsumerAsync") && method.GetGenericArguments().Length==2 && method.GetParameters().Length==5);
+            .First(method => Equals(method.Name, "RegisterPubSubAsyncConsumerAsync") && method.GetGenericArguments().Length==2 && method.GetParameters().Length==6);
         ValueTask<bool> IConsumerContractConnection.RegisterPubSubAsyncConsumerAsync(Type consumerType, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
         {
             var ifaceType = GetConsumerInterfaceType(consumerType, typeof(IPubSubAsyncConsumer<>));
@@ -218,6 +224,7 @@ namespace MQContract.Connections
                 channel,
                 group,
                 ignoreMessageHeader,
+                null,
                 cancellationToken
             ])!;
         }

--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -14,6 +14,7 @@ using MQContract.Subscriptions;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Threading.Channels;
 
 namespace MQContract.Connections
 {
@@ -27,8 +28,6 @@ namespace MQContract.Connections
         : IMetricContractConnection<CC>
         where CC : IBaseContractConnection
     {
-        private static readonly CompressionMiddleware compressionMiddleware = new();
-
         private bool disposedValue;
         protected readonly Guid indentifier = Guid.NewGuid();
         protected readonly SemaphoreSlim dataLock = new(1, 1);
@@ -163,15 +162,41 @@ namespace MQContract.Connections
             );
         }
 
-        protected async ValueTask<(T message, MessageHeader header)> DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes mapType, IMessageFactory<T> messageFactory, ReceivedServiceMessage message, Activity? activity)
+        protected async ValueTask<DecodeServiceMessageResult<T>> DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes mapType, IMessageFactory<T> messageFactory, ReceivedServiceMessage message, Activity? activity,MessageFilters<T>? messageFilters)
         {
             using var scope = SetScope(message.ID);
+            logger?.LogDebug("Filtering Service Message message of type {Type} by headers", typeof(T));
+            var filterResult = (messageFilters!=null && messageFilters.HeaderFilter!=null ? await messageFilters.HeaderFilter(message.Header) : MessageFilterResult.Allow);
+            if (filterResult != MessageFilterResult.Allow)
+            {
+                activity?.AddEvent(new(Constants.MessageFilteredName, tags: new([
+                    new($"{OpenTelemetryMiddleware.KeyBase}.filterresult",filterResult),
+                    new($"{OpenTelemetryMiddleware.KeyBase}.filtertype","header")
+                ])));
+                return DecodeServiceMessageResult<T>.ProduceResult(filterResult);
+            }
             logger?.LogDebug("Decoding Service Message message of type {Type}", typeof(T));
             var context = new Middleware.Context(mapType, activity, expectedType:typeof(T));
             (var messageHeader, var data) = await BeforeMessageDecodeAsync<T>(context, message.ID, message.Header, message.MessageTypeID, message.Channel, message.Data);
             var taskMessage = await messageFactory.ConvertMessageAsync(logger, new ReceivedServiceMessage(message.ID, message.MessageTypeID, message.Channel, messageHeader, data, message.Acknowledge))
                                 ??throw new InvalidCastException($"Unable to convert incoming message {message.MessageTypeID} to {typeof(T).FullName}");
-            return await AfterMessageDecodeAsync<T>(context, taskMessage!, message.ID, messageHeader, message.ReceivedTimestamp, DateTime.Now);
+            filterResult = (messageFilters!=null && messageFilters.MessageFilter!=null ? await messageFilters.MessageFilter(taskMessage, messageHeader) : MessageFilterResult.Allow);
+            if (filterResult != MessageFilterResult.Allow)
+            {
+                context.Activity?.AddEvent(new(Constants.MessageFilteredName, tags: new([
+                    new($"{OpenTelemetryMiddleware.KeyBase}.filterresult",filterResult),
+                    new($"{OpenTelemetryMiddleware.KeyBase}.filtertype","message")
+                ])));
+                return DecodeServiceMessageResult<T>.ProduceResult(filterResult);
+            }
+            (var messageResult,var headerResult)= await AfterMessageDecodeAsync<T>(context, taskMessage!, message.ID, messageHeader, message.ReceivedTimestamp, DateTime.Now);
+            return DecodeServiceMessageResult<T>.ProduceResult(messageResult, headerResult);
+        }
+
+        protected async ValueTask<(T message, MessageHeader header)> DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes mapType, IMessageFactory<T> messageFactory, ReceivedServiceMessage message, Activity? activity)
+        {
+            var decodedResult = await DecodeServiceMessageAsync<T>(mapType, messageFactory, message, activity, null);
+            return (decodedResult.Message!,decodedResult.Header!);
         }
         #endregion
 
@@ -220,16 +245,16 @@ namespace MQContract.Connections
         #endregion
 
         #region Subscriptions
-        protected abstract ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken);
+        protected abstract ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, bool synchronous, CancellationToken cancellationToken);
 
-        ValueTask<ISubscription> IBaseContractConnection.SubscribeAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<ISubscription> IBaseContractConnection.SubscribeAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
         {
             using var scope = SetScope();
             logger?.LogDebug("Creating PubSub subscription for message type {T} on channel {Channel} in group {Group}", typeof(T), channel, group);
-            return CreateSubscriptionAsync<T>(messageReceived, errorReceived, channel, group, ignoreMessageHeader, false, cancellationToken);
+            return CreateSubscriptionAsync<T>(messageReceived, errorReceived, channel, group, ignoreMessageHeader, messageFilters, false, cancellationToken);
         }
 
-        ValueTask<ISubscription> IBaseContractConnection.SubscribeAsync<T>(Action<IReceivedMessage<T>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, CancellationToken cancellationToken)
+        ValueTask<ISubscription> IBaseContractConnection.SubscribeAsync<T>(Action<IReceivedMessage<T>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
         {
             using var scope = SetScope();
             logger?.LogDebug("Creating PubSub subscription for message type {T} on channel {Channel} in group {Group}", typeof(T), channel, group);
@@ -238,7 +263,7 @@ namespace MQContract.Connections
                 messageReceived(msg);
                 return ValueTask.CompletedTask;
             },
-            errorReceived, channel, group, ignoreMessageHeader, true, cancellationToken);
+            errorReceived, channel, group, ignoreMessageHeader, messageFilters, true, cancellationToken);
         }
         protected abstract ValueTask<ISubscription> ProduceSubscribeQueryResponseAsync<Q, R>(Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken);
 
@@ -333,7 +358,8 @@ namespace MQContract.Connections
         }
 
 #pragma warning disable S4136 // Method overloads should be grouped together
-        protected async ValueTask<ISubscription> CreateSubscriptionAsync<T>(IMessageFactory<T> messageFactory, IMessageServiceConnection serviceConnection, Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool synchronous, string? serviceConnectionName, CancellationToken cancellationToken)
+        protected async ValueTask<ISubscription> CreateSubscriptionAsync<T>(IMessageFactory<T> messageFactory, IMessageServiceConnection serviceConnection, Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, 
+            string? channel, string? group, bool synchronous, string? serviceConnectionName, MessageFilters<T>? messageFilters, CancellationToken cancellationToken)
 #pragma warning restore S4136 // Method overloads should be grouped together
         {
             using var scope = SetScope();
@@ -344,8 +370,11 @@ namespace MQContract.Connections
                     using var activity = StartActivity(Constants.ConsumeActivityName, messageHeader:serviceMessage.Header, serviceConnection:serviceConnection, connectionName:serviceConnectionName);
                     try
                     {
-                        (var taskMessage, var messageHeader) = await DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes.PublishSubscription, messageFactory, serviceMessage, activity);
-                        await messageReceived(new ReceivedMessage<T>(serviceMessage.ID, taskMessage!, messageHeader, serviceMessage.ReceivedTimestamp, DateTime.Now, activity));
+                        var decodedResult = await DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes.PublishSubscription, messageFactory, serviceMessage, activity, messageFilters);
+                        if (decodedResult.FilterResult == MessageFilterResult.Allow)
+                            await messageReceived(new ReceivedMessage<T>(serviceMessage.ID, decodedResult.Message!, decodedResult.Header!, serviceMessage.ReceivedTimestamp, DateTime.Now, activity));
+                        else if (decodedResult.FilterResult == MessageFilterResult.DropAndAcknowledge && serviceMessage.Acknowledge != null)
+                            await serviceMessage.Acknowledge();
                         activity?.SetStatus(ActivityStatusCode.Ok);
                     }
                     catch

--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -126,7 +126,7 @@ namespace MQContract.Connections
             return message;
         }
 
-        private async ValueTask<(MessageHeader messageHeader, ReadOnlyMemory<byte> data)> BeforeMessageDecodeAsync<T>(IContext context, string id, MessageHeader messageHeader, string messageTypeID, string messageChannel, ReadOnlyMemory<byte> data)
+        private async ValueTask<(MessageHeader messageHeader, ReadOnlyMemory<byte> data)> BeforeMessageDecodeAsync(IContext context, string id, MessageHeader messageHeader, string messageTypeID, string messageChannel, ReadOnlyMemory<byte> data)
         {
             using var scope = SetScope(id);
             logger?.LogInformation("Executing Before Message Decode middleware");
@@ -177,7 +177,7 @@ namespace MQContract.Connections
             }
             logger?.LogDebug("Decoding Service Message message of type {Type}", typeof(T));
             var context = new Middleware.Context(mapType, activity, expectedType:typeof(T));
-            (var messageHeader, var data) = await BeforeMessageDecodeAsync<T>(context, message.ID, message.Header, message.MessageTypeID, message.Channel, message.Data);
+            (var messageHeader, var data) = await BeforeMessageDecodeAsync(context, message.ID, message.Header, message.MessageTypeID, message.Channel, message.Data);
             var taskMessage = await messageFactory.ConvertMessageAsync(logger, new ReceivedServiceMessage(message.ID, message.MessageTypeID, message.Channel, messageHeader, data, message.Acknowledge))
                                 ??throw new InvalidCastException($"Unable to convert incoming message {message.MessageTypeID} to {typeof(T).FullName}");
             filterResult = (messageFilters!=null && messageFilters.MessageFilter!=null ? await messageFilters.MessageFilter(taskMessage, messageHeader) : MessageFilterResult.Allow);
@@ -373,9 +373,8 @@ namespace MQContract.Connections
                         var decodedResult = await DecodeServiceMessageAsync<T>(ChannelMapper.MapTypes.PublishSubscription, messageFactory, serviceMessage, activity, messageFilters);
                         if (decodedResult.FilterResult == MessageFilterResult.Allow)
                             await messageReceived(new ReceivedMessage<T>(serviceMessage.ID, decodedResult.Message!, decodedResult.Header!, serviceMessage.ReceivedTimestamp, DateTime.Now, activity));
-                        else if (decodedResult.FilterResult == MessageFilterResult.DropAndAcknowledge && serviceMessage.Acknowledge != null)
-                            await serviceMessage.Acknowledge();
                         activity?.SetStatus(ActivityStatusCode.Ok);
+                        return !Equals(decodedResult.FilterResult, MessageFilterResult.DropAndDontAcknowledge);
                     }
                     catch
                     {
@@ -479,7 +478,7 @@ namespace MQContract.Connections
             }
             return (tcs.Task.Result, null);
         }
-        protected async ValueTask<QueryResult<R>> ProduceResultAsync<R>(uint? maxMessageBodySize, ServiceQueryResult queryResult, IMessageServiceConnection serviceConnection, string? serviceConnectionName, string responseChannel = "")
+        protected async ValueTask<QueryResult<R>> ProduceResultAsync<R>(ServiceQueryResult queryResult, IMessageServiceConnection serviceConnection, string? serviceConnectionName, string responseChannel = "")
         {
             using var scope = SetScope(queryResult.ID);
             logger?.LogDebug("Attempting to produce a Query Result of {R} from the Service Message of the type {MessageTypeID}", typeof(R), queryResult.MessageTypeID);
@@ -552,7 +551,6 @@ namespace MQContract.Connections
                                 return new QueryResult<R>(serviceMessage.ID, new([]), Error: new(te));
                             }
                             return await ProduceResultAsync<R>(
-                                serviceConnection.MaxMessageBodySize,
                                 result,
                                 serviceConnection,
                                 connectionName
@@ -569,7 +567,6 @@ namespace MQContract.Connections
                     var (serviceQueryResult, errorMessage)= await ProcessInboxMessageAsync<Q>(connectionName, inboxMessageServiceConnection, serviceMessage, realTimeout??inboxMessageServiceConnection.DefaultTimeout, activity, cancellationToken);
                     if (serviceQueryResult!=null)
                         return await ProduceResultAsync<R>(
-                            serviceConnection.MaxMessageBodySize,
                             serviceQueryResult!,
                             serviceConnection,
                             connectionName
@@ -640,7 +637,7 @@ namespace MQContract.Connections
                 if (!token.IsCancellationRequested)
                     await token.CancelAsync();
             }
-            return await ProduceResultAsync<R>(serviceConnection.MaxMessageBodySize, tcs.Task.Result, serviceConnection, connectionName, responseChannel: responseChannel);
+            return await ProduceResultAsync<R>(tcs.Task.Result, serviceConnection, connectionName, responseChannel: responseChannel);
         }
         protected async ValueTask<ISubscription> CreateSubscriptionAsync<Q, R>(IMessageFactory<Q> queryMessageFactory, IMessageFactory<R> responseMessageFactory, IMessageServiceConnection serviceConnection,
             Func<IReceivedMessage<Q>, ValueTask<QueryResponseMessage<R>>> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool synchronous, string? serviceConnectionName, CancellationToken cancellationToken)

--- a/Core/Connections/Connection.cs
+++ b/Core/Connections/Connection.cs
@@ -49,7 +49,7 @@ namespace MQContract.Connections
         }
 
         #region PubSub
-        protected override ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken)
+        protected override ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, bool synchronous, CancellationToken cancellationToken)
             => CreateSubscriptionAsync<T>(
                 GetMessageFactory<T>(ignoreMessageHeader),
                 serviceConnection,
@@ -59,6 +59,7 @@ namespace MQContract.Connections
                 group,
                 synchronous,
                 null,
+                messageFilters,
                 cancellationToken
             );
 

--- a/Core/Connections/DecodeServiceMessageResult.cs
+++ b/Core/Connections/DecodeServiceMessageResult.cs
@@ -1,0 +1,26 @@
+﻿using MQContract.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQContract.Connections
+{
+    internal record DecodeServiceMessageResult<T>
+    {
+        public T? Message { get; private init; } = default(T?);
+        public MessageHeader? Header { get; private init; } = null;
+        public MessageFilterResult FilterResult { get; private init; } = MessageFilterResult.Allow;
+
+        public static DecodeServiceMessageResult<T> ProduceResult(T message, MessageHeader messageHeader)
+            => new()
+            {
+                Message = message,
+                Header = messageHeader
+            };
+
+        public static DecodeServiceMessageResult<T> ProduceResult(MessageFilterResult messageFilterResult)
+            => new() { FilterResult = messageFilterResult };
+    }
+}

--- a/Core/Connections/MappedConnection.cs
+++ b/Core/Connections/MappedConnection.cs
@@ -72,7 +72,7 @@ namespace MQContract.Connections
         }
 
         #region PubSub
-        protected override async ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken)
+        protected override async ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, bool synchronous, CancellationToken cancellationToken)
         {
             (var connection, channel) = await GetConnectionsAsync<T>(channel, ChannelMapper.MapTypes.PublishSubscription);
             return await CreateSubscriptionAsync<T>(
@@ -84,6 +84,7 @@ namespace MQContract.Connections
                 group,
                 synchronous,
                 connection.ServiceConnectionName,
+                messageFilters,
                 cancellationToken
             );
         }

--- a/Core/Connections/MultiServiceConnection.cs
+++ b/Core/Connections/MultiServiceConnection.cs
@@ -125,7 +125,7 @@ namespace MQContract.Connections
                 .Select(grp => new MultiTransmissionResult(grp.Key, grp.SelectMany(g => g.Results)));
         }
 
-        protected override async ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, bool synchronous, CancellationToken cancellationToken)
+        protected override async ValueTask<ISubscription> CreateSubscriptionAsync<T>(Func<IReceivedMessage<T>, ValueTask> messageReceived, Action<Exception> errorReceived, string? channel, string? group, bool ignoreMessageHeader, MessageFilters<T>? messageFilters, bool synchronous, CancellationToken cancellationToken)
         {
             var messageFactory = GetMessageFactory<T>(ignoreMessageHeader);
             (var connections, channel) = await GetConnectionsAsync<T>(channel, ChannelMapper.MapTypes.PublishSubscription);
@@ -139,6 +139,7 @@ namespace MQContract.Connections
                     group,
                     synchronous,
                     conn.ServiceConnectionName,
+                    messageFilters,
                     cancellationToken
                 ))
             );

--- a/Core/Constants.cs
+++ b/Core/Constants.cs
@@ -11,6 +11,7 @@
         public const string ProduceQueryResponseActivityName = $"{BaseActivityName}.ProduceQueryResponse";
         public const string ConsumeQueryResponseActivityName = $"{BaseActivityName}.ConsumeQueryResponse";
         public const string PublishBulkMessagesMessageEvent = "BulkMessagePublished";
+        public const string MessageFilteredName = $"{BaseActivityName}.MessageFiltered";
 
         public const string BulkPublishCountTag = "mqcontract.bulkmessagecount";
 

--- a/Core/Subscriptions/PubSubSubscription.cs
+++ b/Core/Subscriptions/PubSubSubscription.cs
@@ -4,7 +4,7 @@ using MQContract.Messages;
 
 namespace MQContract.Subscriptions
 {
-    internal sealed class PubSubSubscription<T>(Func<ReceivedServiceMessage, ValueTask> messageReceived, Action<Exception> errorReceived,
+    internal sealed class PubSubSubscription<T>(Func<ReceivedServiceMessage, ValueTask<bool>> messageReceived, Action<Exception> errorReceived,
         Func<string, ValueTask<string>> mapChannel,
         string? channel = null, string? group = null, bool synchronous = false, ILogger? logger = null)
         : SubscriptionBase<T>(mapChannel, channel, synchronous, logger)
@@ -33,8 +33,8 @@ namespace MQContract.Subscriptions
             {
                 Logger?.LogDebug("Processing service message with ID: {MessageID}", serviceMessage.ID);
                 var tsk = messageReceived(serviceMessage);
-                await tsk.ConfigureAwait(!Synchronous);
-                if (serviceMessage.Acknowledge!=null)
+                var ack = await tsk.ConfigureAwait(!Synchronous);
+                if (serviceMessage.Acknowledge!=null && ack)
                 {
                     Logger?.LogDebug("Acknowledging service message with ID: {MessageID}", serviceMessage.ID);
                     await serviceMessage.Acknowledge();

--- a/Samples/Messages/SampleExecution.cs
+++ b/Samples/Messages/SampleExecution.cs
@@ -28,7 +28,8 @@ namespace Messages
                     Console.WriteLine($"Announcing the arrival of {announcement.Message.LastName}, {announcement.Message.FirstName} in member 1 of the group.. [{announcement.ID},{announcement.ReceivedTimestamp}]");
                     return ValueTask.CompletedTask;
                 },
-                (error) => {
+                (error) =>
+                {
                     Console.WriteLine($"Announcement error: {error.Message}");
                 },
                 group: "AnnouncementGroup",

--- a/Samples/NATSSample/NATSSample.csproj
+++ b/Samples/NATSSample/NATSSample.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.props
+++ b/Shared.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<VersionPrefix>2.8.1</VersionPrefix>
+		<VersionPrefix>2.9</VersionPrefix>
 		<PackageProjectUrl>https://github.com/roger-castaldo/MQContract</PackageProjectUrl>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/roger-castaldo/MQContract</RepositoryUrl>


### PR DESCRIPTION
Added in the ability to register a message filter for a given subscription.  This filter will occur prior to decoding when header based and prior to callback/middleware once decoded.