### PR TITLE
updated message checks

### DIFF
--- a/Abstractions/Exceptions.cs
+++ b/Abstractions/Exceptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace MQContract
+﻿namespace MQContract
 {
     /// <summary>
     /// Thrown when an error occurs attempting to transmit a given message and is flagged if it is fatal or not

--- a/Abstractions/Messages/MessageFilters.cs
+++ b/Abstractions/Messages/MessageFilters.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.Messages
+﻿namespace MQContract.Messages
 {
     /// <summary>
     /// Houses a set of message filtering calls for a given type.  This particular record can be passed in to pubsub consumers/subscriptions

--- a/AutomatedTesting/ChannelMapperTests.cs
+++ b/AutomatedTesting/ChannelMapperTests.cs
@@ -282,7 +282,7 @@ namespace AutomatedTesting
 
             #region Assert
             Assert.IsNotNull(subscription);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(newChannel, channels[0]);
             #endregion
 
@@ -335,7 +335,7 @@ namespace AutomatedTesting
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion
@@ -387,7 +387,7 @@ namespace AutomatedTesting
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.AreEqual(newChannel, channels[1]);
             #endregion
@@ -440,7 +440,7 @@ namespace AutomatedTesting
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion
@@ -492,7 +492,7 @@ namespace AutomatedTesting
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion
@@ -814,7 +814,7 @@ namespace AutomatedTesting
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount<string>(channels, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(newChannel, channels[0]);
             #endregion
 
@@ -871,7 +871,7 @@ namespace AutomatedTesting
             Assert.IsTrue(await Helper.WaitForCount<string>(channels, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion
@@ -927,7 +927,7 @@ namespace AutomatedTesting
             Assert.IsTrue(await Helper.WaitForCount<string>(channels, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.AreEqual(newChannel, channels[1]);
             #endregion
@@ -984,7 +984,7 @@ namespace AutomatedTesting
             Assert.IsTrue(await Helper.WaitForCount<string>(channels, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion
@@ -1040,7 +1040,7 @@ namespace AutomatedTesting
             Assert.IsTrue(await Helper.WaitForCount<string>(channels, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(newChannel, channels[0]);
             Assert.AreEqual(otherChannel, channels[1]);
             #endregion

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubAsyncConsumerTests.cs
@@ -1,13 +1,11 @@
 ﻿using AutomatedTesting.Consumers;
 using AutomatedTesting.Messages;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Moq;
 using MQContract;
 using MQContract.Attributes;
 using MQContract.Interfaces;
 using MQContract.Interfaces.Consumers;
 using MQContract.Interfaces.Service;
-using MQContract.Messages;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -78,12 +76,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -168,10 +166,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
             Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
             #endregion
@@ -246,10 +244,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
             Assert.AreEqual(typeof(BasicMessageAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
             #endregion
@@ -391,12 +389,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -405,7 +403,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.AreEqual(message, messages[0].Message);
             Assert.AreEqual(exception, exceptions[0]);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 publishedMessages[0],
                 capturedActivities[0],
@@ -498,12 +496,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -512,7 +510,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.AreEqual(message, messages[0].Message);
             Assert.AreEqual(exception, exceptions[0]);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 publishedMessages[0],
                 capturedActivities[0],
@@ -617,8 +615,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, serviceMessages);
             if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
             {
                 Assert.IsTrue(await Helper.WaitForCount(BasicMessageAsyncConsumer.Messages, 1, TimeSpan.FromMinutes(1)));
@@ -629,7 +627,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             }
             else
             {
-                Assert.AreEqual(0, BasicMessageAsyncConsumer.Messages.Count);
+                Assert.IsEmpty(BasicMessageAsyncConsumer.Messages);
             }
             Assert.AreEqual(acknowledgeDrop, acknowledged);
             #endregion

--- a/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/PubSubConsumerTests.cs
@@ -75,12 +75,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -165,10 +165,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             #endregion
@@ -243,10 +243,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             #endregion
@@ -378,12 +378,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -468,12 +468,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -586,8 +586,8 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, serviceMessages);
             if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
             {
                 Assert.IsTrue(await Helper.WaitForCount(BasicMessageConsumer.Messages, 1, TimeSpan.FromMinutes(1)));
@@ -598,7 +598,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             }
             else
             {
-                Assert.AreEqual(0, BasicMessageConsumer.Messages.Count);
+                Assert.IsEmpty(BasicMessageConsumer.Messages);
             }
             Assert.AreEqual(acknowledgeDrop, acknowledged);
             #endregion

--- a/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/QueryResponseAsyncConsumerTests.cs
@@ -78,12 +78,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -171,10 +171,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
             Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
             #endregion
@@ -249,10 +249,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerMessageChannelAttribute>(false)!.Name, channels[0]);
             Assert.AreEqual(typeof(BasicQueryAsyncConsumer).GetCustomAttribute<ConsumerGroupAttribute>(false)!.Name, groups[0]);
             #endregion
@@ -398,12 +398,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -415,7 +415,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 serviceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/Consumers/QueryResponseConsumerTests.cs
+++ b/AutomatedTesting/ConnectionTests/Consumers/QueryResponseConsumerTests.cs
@@ -78,12 +78,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -171,10 +171,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             #endregion
@@ -249,10 +249,10 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             #region Assert
             Assert.IsTrue(registrationResult);
             await contractConnection.CloseAsync();
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             #endregion
@@ -397,12 +397,12 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             await contractConnection.CloseAsync();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -414,7 +414,7 @@ namespace AutomatedTesting.ConnectionTests.Consumers
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 serviceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/MappedService/BulkPublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/BulkPublishTests.cs
@@ -45,7 +45,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, testMessages.Count(), TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -93,7 +93,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(2, messages.Count);
+            Assert.HasCount(2, messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(channelName, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -140,7 +140,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(2, messages.Count);
+            Assert.HasCount(2, messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(Constants.BasicMessageType, m.MessageTypeID)
@@ -188,7 +188,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -241,7 +241,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, testMessages.Count(), TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals((withLinking ? 2 : 0), m.Header.Keys.Count())
@@ -250,7 +250,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             ));
             Assert.AreEqual(testMessages.ElementAt(0).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(testMessages.ElementAt(1).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[1].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidateBulkPublishActivity<BasicMessage>(
                 messages,
                 capturedActivities[0],
@@ -302,7 +302,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals((withLinking ? 2 : 0), m.Header.Keys.Count())
@@ -311,7 +311,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             ));
             Assert.AreEqual(testMessages.ElementAt(0).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].ElementAt(0).Data.ToArray())));
             Assert.AreEqual(testMessages.ElementAt(1).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].ElementAt(1).Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidateBulkPublishActivity<BasicMessage>(
                 messages.SelectMany(m => m),
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MappedService/HealthCheckTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/HealthCheckTests.cs
@@ -30,7 +30,6 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Healthy, checkResult.Status);
             Assert.AreEqual(Constants.HealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -67,7 +66,6 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Unhealthy, checkResult.Status);
             Assert.AreEqual(Constants.UnHealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -97,7 +95,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(error);
             Assert.AreEqual("serviceConnectionList", error.ParamName);
-            Assert.IsTrue(error.Message.StartsWith("No Pingable service connections provided, cannot provide health checks"));
+            Assert.StartsWith("No Pingable service connections provided, cannot provide health checks", error.Message);
             #endregion
 
             #region Verify
@@ -126,7 +124,6 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Healthy, checkResult.Status);
             Assert.AreEqual(Constants.HealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -175,7 +172,6 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Degraded, checkResult.Status);
             Assert.AreEqual(Constants.DegradedDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));

--- a/AutomatedTesting/ConnectionTests/MappedService/PublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/PublishTests.cs
@@ -53,7 +53,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -93,7 +93,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual($"Not{typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -134,7 +134,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
             Assert.IsTrue(messageHeader.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -180,7 +180,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -227,7 +227,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             #endregion
 
@@ -275,7 +275,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(binaries[0].Reverse().ToArray()), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
             Assert.IsTrue(headers.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -319,7 +319,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -359,7 +359,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -402,7 +402,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -443,7 +443,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             #endregion
@@ -485,7 +485,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             #endregion
@@ -558,7 +558,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -603,7 +603,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
 
             Assert.IsNotNull(result2);
@@ -611,7 +611,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual("TestChannel2", messages[1].Channel);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             #endregion
 
@@ -719,9 +719,9 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MappedService/QueryInboxTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/QueryInboxTests.cs
@@ -79,10 +79,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -250,10 +250,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -335,10 +335,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -421,13 +421,13 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MappedService/QueryTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/QueryTests.cs
@@ -63,11 +63,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -118,11 +118,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual($"Not{typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -175,10 +175,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
@@ -233,11 +233,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(timeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -290,12 +290,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -358,11 +358,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -428,10 +428,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray().Reverse().ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
@@ -485,11 +485,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(typeof(TimeoutMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(TimeSpan.FromMilliseconds(typeof(TimeoutMessage).GetCustomAttribute<MessageResponseTimeoutAttribute>(false)?.Value ?? 0), timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.TimeoutMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<TimeoutMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -540,11 +540,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -595,11 +595,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -652,11 +652,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -709,10 +709,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.Result);
@@ -766,10 +766,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.Result);
@@ -863,7 +863,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -918,11 +918,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result1.Error);
             Assert.IsFalse(result1.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(2, timeouts.Count);
+            Assert.HasCount(2, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result1.Result);
 
@@ -934,7 +934,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(defaultTimeout, timeouts[1]);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             Assert.AreEqual(responseMessage, result2.Result);
             #endregion
@@ -985,11 +985,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -1203,14 +1203,14 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MappedService/QueryWithoutQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/QueryWithoutQueryResponseTests.cs
@@ -71,10 +71,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -139,10 +139,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(4, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -213,10 +213,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -278,10 +278,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -458,16 +458,16 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual((withLinking ? 5 : 3), messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                  messages[0],
                  capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MappedService/SubscribeQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/SubscribeQueryResponseTests.cs
@@ -76,12 +76,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -140,7 +140,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -186,7 +186,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -363,12 +363,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -443,12 +443,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -659,7 +659,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.IsError);
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.Error?.Message));
-            Assert.IsTrue(result.Error!.Message.Contains(typeof(BasicResponseMessage).FullName!));
+            Assert.Contains(typeof(BasicResponseMessage).FullName??"", result.Error!.Message);
             #endregion
 
             #region Verify
@@ -828,12 +828,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -845,7 +845,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 serviceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/MappedService/SubscribeQueryResponseWithoutQueryResponseTest.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/SubscribeQueryResponseWithoutQueryResponseTest.cs
@@ -70,10 +70,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -84,7 +84,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
             #endregion
 
@@ -148,14 +148,14 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(error);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(1, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(1, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
-            Assert.AreEqual(0, receivedMessages.Count);
+            Assert.IsEmpty(receivedMessages);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.IsInstanceOfType<InvalidQueryResponseMessageReceivedException>(exceptions[0]);
             #endregion
@@ -234,10 +234,10 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -248,9 +248,9 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 receivedServiceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/MappedService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/MappedService/SubscribeTests.cs
@@ -73,12 +73,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -153,11 +153,11 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -199,7 +199,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -234,7 +234,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -482,12 +482,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
             Assert.IsNotNull(result2);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -555,12 +555,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -618,16 +618,15 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
-            Assert.IsInstanceOfType<InvalidDataException>(exceptions[0]);
-            Assert.AreEqual("MetaData is not valid", exceptions[0].Message);
+            Assert.IsInstanceOfType<InvalidCastException>(exceptions[0]);
             #endregion
 
             #region Verify
@@ -690,12 +689,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -776,12 +775,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -852,12 +851,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -928,15 +927,15 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(1, exceptions.OfType<InvalidCastException>().Count());
-            Assert.IsTrue(exceptions.Contains(exception));
+            Assert.Contains(exception, exceptions);
             #endregion
 
             #region Verify
@@ -1086,12 +1085,12 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -1101,7 +1100,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             Assert.AreEqual(exception, exceptions[0]);
             Assert.IsTrue(acknowledged);
             Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 publishedMessages[0],
                 capturedActivities[0],
@@ -1207,8 +1206,8 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             #region Assert
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, serviceMessages);
             if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
             {
                 Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
@@ -1219,7 +1218,7 @@ namespace AutomatedTesting.ConnectionTests.MappedService
             }
             else
             {
-                Assert.AreEqual(0, messages.Count);
+                Assert.IsEmpty(messages);
             }
             Assert.AreEqual(acknowledgeDrop, acknowledged);
             #endregion

--- a/AutomatedTesting/ConnectionTests/MiddleWareTests.cs
+++ b/AutomatedTesting/ConnectionTests/MiddleWareTests.cs
@@ -95,7 +95,7 @@ namespace AutomatedTesting.ContractConnectionTests
 
             #region Assert
             Assert.IsNotNull(error);
-            Assert.IsTrue(error.Message.Contains(typeof(InvalidMiddleware).ToString()));
+            Assert.Contains(typeof(InvalidMiddleware).ToString(), error.Message);
             #endregion
 
             #region Verify
@@ -407,7 +407,7 @@ namespace AutomatedTesting.ContractConnectionTests
 
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount<ServiceMessage>(messages, 1, TimeSpan.FromMinutes(1)));
-            Assert.AreEqual(messages[0].Channel, expectedChannel);
+            Assert.AreEqual(expectedChannel, messages[0].Channel);
             #endregion
 
             #region Verify

--- a/AutomatedTesting/ConnectionTests/MultiService/BulkPublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/BulkPublishTests.cs
@@ -49,7 +49,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[1].ID);
             Assert.IsTrue(messages.TrueForAll(m =>
@@ -101,7 +101,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[1].ID);
             Assert.IsTrue(messages.TrueForAll(m =>
@@ -153,7 +153,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(2, result.Count());
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[1].ID);
             Assert.IsTrue(messages.TrueForAll(m =>
@@ -205,7 +205,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ElementAt(0).ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[0].ElementAt(1).ID);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>
@@ -261,7 +261,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[1].ID);
             Assert.IsTrue(messages.TrueForAll(m =>
@@ -272,7 +272,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             ));
             Assert.AreEqual(testMessages.ElementAt(0).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(testMessages.ElementAt(1).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[1].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidateBulkPublishActivity<BasicMessage>(
                 messages,
                 capturedActivities[0],
@@ -326,7 +326,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => r.Results.Count()==1));
             Assert.IsTrue(result.SelectMany(r => r.Results).All(r => !r.IsError && Equals(ServiceName, r.ServiceName)));
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ElementAt(0).ID, messages[0].ElementAt(0).ID);
             Assert.AreEqual(result.ElementAt(1).ID, messages[0].ElementAt(1).ID);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>

--- a/AutomatedTesting/ConnectionTests/MultiService/HealthCheckTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/HealthCheckTests.cs
@@ -32,7 +32,6 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Healthy, checkResult.Status);
             Assert.AreEqual(Constants.HealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -71,7 +70,6 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Unhealthy, checkResult.Status);
             Assert.AreEqual(Constants.UnHealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -103,7 +101,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(error);
             Assert.AreEqual("serviceConnectionList", error.ParamName);
-            Assert.IsTrue(error.Message.StartsWith("No Pingable service connections provided, cannot provide health checks"));
+            Assert.StartsWith("No Pingable service connections provided, cannot provide health checks", error.Message);
             #endregion
 
             #region Verify
@@ -133,7 +131,6 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Healthy, checkResult.Status);
             Assert.AreEqual(Constants.HealthyDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));
@@ -183,7 +180,6 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Degraded, checkResult.Status);
             Assert.AreEqual(Constants.DegradedDescription, checkResult.Description);
             Assert.IsTrue(checkResult.Data.TryGetValue(ServiceName, out var value));

--- a/AutomatedTesting/ConnectionTests/MultiService/MapTesting.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/MapTesting.cs
@@ -44,7 +44,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(serviceName, result.Results.First().ServiceName);
@@ -90,7 +90,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(serviceName, result.Results.First().ServiceName);
@@ -136,7 +136,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(serviceName, result.Results.First().ServiceName);
@@ -184,7 +184,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(serviceName, result.Results.First().ServiceName);

--- a/AutomatedTesting/ConnectionTests/MultiService/PublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/PublishTests.cs
@@ -52,7 +52,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -61,7 +61,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -98,7 +98,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -107,7 +107,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual($"Not{typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -146,7 +146,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -154,7 +154,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsFalse(result.HasError);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
             Assert.IsTrue(messageHeader.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -196,7 +196,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -206,7 +206,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -250,7 +250,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -259,7 +259,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             #endregion
 
@@ -305,7 +305,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -313,7 +313,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsFalse(result.HasError);
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(binaries[0].Reverse().ToArray()), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
             Assert.IsTrue(headers.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -354,7 +354,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -363,7 +363,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -400,7 +400,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -409,7 +409,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -449,7 +449,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -458,7 +458,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -497,14 +497,14 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
             Assert.IsFalse(result.Results.First().IsError);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             #endregion
@@ -544,14 +544,14 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
             Assert.IsFalse(result.Results.First().IsError);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             #endregion
@@ -626,7 +626,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -675,7 +675,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
 
             Assert.IsNotNull(result2);
@@ -686,7 +686,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual("TestChannel2", messages[1].Channel);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             #endregion
 
@@ -727,7 +727,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.AreEqual(result.ID, messages[0].ID);
             Assert.AreEqual(1, result.Results.Count());
             Assert.AreEqual(ServiceName, result.Results.First().ServiceName);
@@ -736,9 +736,9 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MultiService/QueryInboxTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/QueryInboxTests.cs
@@ -83,10 +83,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -258,10 +258,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -345,10 +345,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -432,13 +432,13 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MultiService/QueryTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/QueryTests.cs
@@ -67,11 +67,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -124,11 +124,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual($"Not{typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -183,10 +183,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
@@ -243,11 +243,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(timeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -302,12 +302,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -372,11 +372,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -444,10 +444,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray().Reverse().ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
@@ -503,11 +503,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(TimeoutMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(TimeSpan.FromMilliseconds(typeof(TimeoutMessage).GetCustomAttribute<MessageResponseTimeoutAttribute>(false)?.Value ?? 0), timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.TimeoutMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<TimeoutMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -560,11 +560,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -617,11 +617,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -676,11 +676,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -735,10 +735,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.First().Result);
@@ -794,10 +794,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.First().Result);
@@ -893,7 +893,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -950,11 +950,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result1.First().Error);
             Assert.IsFalse(result1.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(2, timeouts.Count);
+            Assert.HasCount(2, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result1.First().Result);
 
@@ -967,7 +967,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(defaultTimeout, timeouts[1]);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             Assert.AreEqual(responseMessage, result2.First().Result);
             #endregion
@@ -1020,11 +1020,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             #endregion
@@ -1158,14 +1158,14 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MultiService/QueryWithoutQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/QueryWithoutQueryResponseTests.cs
@@ -74,10 +74,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -144,10 +144,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(4, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -220,10 +220,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -287,10 +287,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -471,16 +471,16 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.IsFalse(result.First().IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual((withLinking ? 5 : 3), messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.First().Result);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                  messages[0],
                  capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/MultiService/SubscribeQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/SubscribeQueryResponseTests.cs
@@ -77,12 +77,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -142,7 +142,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -189,7 +189,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -370,12 +370,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -451,12 +451,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -750,12 +750,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -767,7 +767,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNull(result.First().Error);
             Assert.AreEqual(result.First().Result, responseMessage);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 serviceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/MultiService/SubscribeQueryResponseWithoutQueryResponseTest.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/SubscribeQueryResponseWithoutQueryResponseTest.cs
@@ -72,10 +72,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -86,7 +86,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsFalse(result.First().IsError);
             Assert.IsNull(result.First().Error);
             Assert.AreEqual(result.First().Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
             #endregion
 
@@ -152,14 +152,14 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(error);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(1, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(1, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
-            Assert.AreEqual(0, receivedMessages.Count);
+            Assert.IsEmpty(receivedMessages);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.IsInstanceOfType<InvalidQueryResponseMessageReceivedException>(exceptions[0]);
             #endregion
@@ -237,10 +237,10 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -251,9 +251,9 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsFalse(result.First().IsError);
             Assert.IsNull(result.First().Error);
             Assert.AreEqual(result.First().Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 receivedServiceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/MultiService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/MultiService/SubscribeTests.cs
@@ -75,12 +75,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -156,11 +156,11 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -203,7 +203,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -239,7 +239,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -494,12 +494,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
             Assert.IsNotNull(result2);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -568,12 +568,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -632,16 +632,15 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
-            Assert.IsInstanceOfType<InvalidDataException>(exceptions[0]);
-            Assert.AreEqual("MetaData is not valid", exceptions[0].Message);
+            Assert.IsInstanceOfType<InvalidCastException>(exceptions[0]);
             #endregion
 
             #region Verify
@@ -705,12 +704,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -792,12 +791,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -869,12 +868,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -946,15 +945,15 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(1, exceptions.OfType<InvalidCastException>().Count());
-            Assert.IsTrue(exceptions.Contains(exception));
+            Assert.Contains(exception, exceptions);
             #endregion
 
             #region Verify
@@ -1029,12 +1028,12 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -1044,7 +1043,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             Assert.AreEqual(exception, exceptions[0]);
             Assert.IsTrue(acknowledged);
             Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 publishedMessages[0],
                 capturedActivities[0],
@@ -1151,8 +1150,8 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             #region Assert
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, serviceMessages);
             if (Equals(headerValue, checkValue) && Equals(messageHeaderValue, messageHeaderCheckValue) && Equals(messageValue, messageCheckValue))
             {
                 Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
@@ -1163,7 +1162,7 @@ namespace AutomatedTesting.ConnectionTests.MultiService
             }
             else
             {
-                Assert.AreEqual(0, messages.Count);
+                Assert.IsEmpty(messages);
             }
             Assert.AreEqual(acknowledgeDrop, acknowledged);
             #endregion

--- a/AutomatedTesting/ConnectionTests/SingleService/BulkPublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/BulkPublishTests.cs
@@ -44,7 +44,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, testMessages.Count(), TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -92,7 +92,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(2, messages.Count);
+            Assert.HasCount(2, messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(channelName, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -139,7 +139,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(2, messages.Count);
+            Assert.HasCount(2, messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(Constants.BasicMessageType, m.MessageTypeID)
@@ -187,7 +187,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals(0, m.Header.Keys.Count())
@@ -239,7 +239,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, testMessages.Count(), TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => Equals(r, transmissionResult)));
-            Assert.AreEqual(testMessages.Count(), messages.Count);
+            Assert.HasCount(testMessages.Count(), messages);
             Assert.IsTrue(messages.TrueForAll(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals((withLinking ? 2 : 0), m.Header.Keys.Count())
@@ -248,7 +248,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             ));
             Assert.AreEqual(testMessages.ElementAt(0).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(testMessages.ElementAt(1).message, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[1].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidateBulkPublishActivity<BasicMessage>(
                 messages,
                 capturedActivities[0],
@@ -299,7 +299,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(result);
             Assert.IsTrue(result.All(r => messages.Any(m => m.Any(m => Equals(r.ID, m.ID)))));
-            Assert.AreEqual(1, messages.Count);
+            Assert.HasCount(1, messages);
             Assert.IsTrue(messages.SelectMany(messageSet => messageSet.Select(m => m)).All(m =>
                 Equals(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, m.Channel)
                 && Equals((withLinking ? 2 : 0), m.Header.Keys.Count())

--- a/AutomatedTesting/ConnectionTests/SingleService/HealthCheckTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/HealthCheckTests.cs
@@ -28,7 +28,6 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Healthy,checkResult.Status);
             Assert.AreEqual(Constants.HealthyDescription, checkResult.Description);
             Assert.AreEqual(pingResult.Host, checkResult.Data["Host"]);
@@ -62,7 +61,6 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #endregion
 
             #region Assert
-            Assert.IsNotNull(checkResult);
             Assert.AreEqual(HealthStatus.Unhealthy, checkResult.Status);
             Assert.AreEqual(Constants.UnHealthyDescription, checkResult.Description);
             Assert.AreEqual(error, checkResult.Exception);
@@ -89,7 +87,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(error);
             Assert.AreEqual("connection", error.ParamName);
-            Assert.IsTrue(error.Message.StartsWith("Service connection is not Pingable"));
+            Assert.StartsWith("Service connection is not Pingable", error.Message);
             #endregion
 
             #region Verify

--- a/AutomatedTesting/ConnectionTests/SingleService/PublishTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/PublishTests.cs
@@ -52,7 +52,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -92,7 +92,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual($"Not{typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -133,7 +133,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
             Assert.IsTrue(messageHeader.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -179,7 +179,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -226,7 +226,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             #endregion
 
@@ -274,7 +274,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual("BasicMessage", messages[0].Channel);
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(binaries[0].Reverse().ToArray()), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
             Assert.IsTrue(headers.Keys.All(k => messages[0].Header.Keys.Contains(k)));
@@ -318,7 +318,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, JsonSerializer.Deserialize<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -358,7 +358,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             #endregion
 
@@ -401,7 +401,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -442,7 +442,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             #endregion
@@ -484,7 +484,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(transmissionResult, result);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             #endregion
@@ -557,7 +557,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -602,7 +602,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
 
             Assert.IsNotNull(result2);
@@ -610,7 +610,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual("TestChannel2", messages[1].Channel);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             #endregion
 
@@ -661,9 +661,9 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(0, capturedActivities.Count);
+            Assert.IsEmpty(capturedActivities);
             #endregion
 
             #region Verify
@@ -714,9 +714,9 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 messages[0],
                 capturedActivities[0],
@@ -766,9 +766,9 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(2, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 messages[0],
                 capturedActivities[0],
@@ -818,9 +818,9 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicMessage>(new MemoryStream(messages[0].Data.ToArray())));
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/SingleService/QueryInboxTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/QueryInboxTests.cs
@@ -78,10 +78,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -249,10 +249,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -334,10 +334,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -419,13 +419,13 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, messageIDs.Count);
+            Assert.HasCount(1, messageIDs);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],
@@ -501,7 +501,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(result.IsError);
             Assert.IsNotNull(result.Error);
             Assert.AreEqual(errorMessage, result.Error.Exception.Message);
-            Assert.AreEqual(1, capturedActivities.Count);
+            Assert.HasCount(1, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/SingleService/QueryTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/QueryTests.cs
@@ -62,11 +62,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -117,11 +117,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual($"Not{typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name}", messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -174,10 +174,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.AreEqual(messageHeader.Keys.Count(), messages[0].Header.Keys.Count());
@@ -232,11 +232,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(timeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -289,12 +289,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(1, messages[0].Header.Keys.Count());
             Assert.AreEqual("true", messages[0].Header[messages[0].Header.Keys.First()]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(
                 new GZipStream(new MemoryStream(messages[0].Data.ToArray()), CompressionMode.Decompress)
             ));
@@ -357,11 +357,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(Convert.ToBase64String(encodedData), Convert.ToBase64String(messages[0].Data.ToArray()));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -427,10 +427,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray().Reverse().ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.AreEqual(headers.Count, messages[0].Header.Keys.Count());
@@ -484,11 +484,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(typeof(TimeoutMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(TimeSpan.FromMilliseconds(typeof(TimeoutMessage).GetCustomAttribute<MessageResponseTimeoutAttribute>(false)?.Value ?? 0), timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.TimeoutMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<TimeoutMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -539,11 +539,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.NamedAndVersionedMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<NamedAndVersionedMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -594,11 +594,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncoderMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await new TestMessageEncoder().DecodeAsync(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -651,11 +651,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncoderWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.CustomEncoderWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage,
                 await new TestMessageEncoderWithInjection(services.GetRequiredService<IInjectableService>()).DecodeAsync(new MemoryStream(messages[0].Data.ToArray()))
             );
@@ -708,10 +708,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncryptorMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptor().DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.Result);
@@ -765,10 +765,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(CustomEncryptorWithInjectionMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(Constants.CustomEncryptorWithInjectionMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             var decodedData = await new TestMessageEncryptorWithInjection(services.GetRequiredService<IInjectableService>()).DecryptAsync(new MemoryStream(messages[0].Data.ToArray()), messages[0].Header);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<CustomEncryptorWithInjectionMessage>(decodedData));
             Assert.AreEqual(responseMessage, result.Result);
@@ -862,7 +862,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
 
             #region Assert
             Assert.IsNotNull(exception);
-            Assert.IsTrue(exception.Message.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},"));
+            Assert.StartsWith($"message data exceeds maxmium message size (MaxSize:{serviceConnection.Object.MaxMessageBodySize},", exception.Message);
             Assert.AreEqual("message", exception.ParamName);
             #endregion
 
@@ -917,11 +917,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result1.Error);
             Assert.IsFalse(result1.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(2, timeouts.Count);
+            Assert.HasCount(2, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage1, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result1.Result);
 
@@ -933,7 +933,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(defaultTimeout, timeouts[1]);
             Assert.AreEqual(0, messages[1].Header.Keys.Count());
             Assert.AreEqual(Constants.NoChannelMessageType, messages[1].MessageTypeID);
-            Assert.IsTrue(messages[1].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[1].Data.Length);
             Assert.AreEqual(testMessage2, await JsonSerializer.DeserializeAsync<NoChannelMessage>(new MemoryStream(messages[1].Data.ToArray())));
             Assert.AreEqual(responseMessage, result2.Result);
             #endregion
@@ -984,11 +984,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual(0, messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             #endregion
@@ -1118,14 +1118,14 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, timeouts.Count);
+            Assert.HasCount(1, timeouts);
             Assert.AreEqual(defaultTimeout, timeouts[0]);
             Assert.AreEqual((withLinking ? 2 : 0), messages[0].Header.Keys.Count());
             Assert.AreEqual(Constants.BasicQueryMessageType, messages[0].MessageTypeID);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                 messages[0],
                 capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/SingleService/QueryWithoutQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/QueryWithoutQueryResponseTests.cs
@@ -70,10 +70,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -138,10 +138,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(4, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -212,10 +212,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -277,10 +277,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
@@ -466,16 +466,16 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.IsFalse(result.IsError);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, messages[0].Channel);
-            Assert.AreEqual(1, channels.Count);
+            Assert.HasCount(1, channels);
             Assert.AreEqual(responseChannel, channels[0]);
-            Assert.AreEqual(1, messages.Count);
-            Assert.IsTrue(messages[0].Data.Length > 0);
+            Assert.HasCount(1, messages);
+            Assert.IsGreaterThan(0, messages[0].Data.Length);
             Assert.AreEqual((withLinking ? 5 : 3), messages[0].Header.Keys.Count());
             Assert.AreEqual(responseChannel, messages[0].Header[REPLY_CHANNEL_HEADER]);
             Assert.AreEqual(testMessage, await JsonSerializer.DeserializeAsync<BasicQueryMessage>(new MemoryStream(messages[0].Data.ToArray())));
             Assert.AreEqual(responseMessage, result.Result);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicQueryMessage>(
                  messages[0],
                  capturedActivities[0],

--- a/AutomatedTesting/ConnectionTests/SingleService/SubscribeQueryResponseTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/SubscribeQueryResponseTests.cs
@@ -75,12 +75,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -139,7 +139,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -185,7 +185,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -399,12 +399,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -479,12 +479,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -772,12 +772,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, receivedActions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, receivedActions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -789,7 +789,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
             Assert.IsTrue(acknowledged);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 serviceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/SingleService/SubscribeQueryResponseWithoutQueryResponseTest.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/SubscribeQueryResponseWithoutQueryResponseTest.cs
@@ -69,10 +69,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -83,7 +83,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
             #endregion
 
@@ -147,14 +147,14 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(error);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(1, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(1, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
-            Assert.AreEqual(0, receivedMessages.Count);
+            Assert.IsEmpty(receivedMessages);
             Assert.AreEqual(3, messages[0].Header.Keys.Count());
             Assert.IsInstanceOfType<InvalidQueryResponseMessageReceivedException>(exceptions[0]);
             #endregion
@@ -231,10 +231,10 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, channels.Count);
-            Assert.AreEqual(2, groups.Count);
-            Assert.AreEqual(2, messages.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(2, channels);
+            Assert.HasCount(2, groups);
+            Assert.HasCount(2, messages);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicQueryMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.IsNotNull(groups[1]);
@@ -245,9 +245,9 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsFalse(result.IsError);
             Assert.IsNull(result.Error);
             Assert.AreEqual(result.Result, responseMessage);
-            Assert.AreEqual(2, errorHandlers.Count);
+            Assert.HasCount(2, errorHandlers);
             Assert.AreEqual(testError, exceptions[0]);
-            Assert.AreEqual(4, capturedActivities.Count);
+            Assert.HasCount(4, capturedActivities);
             ConnectionHelper.ValidateConsumeActivity<BasicQueryMessage>(
                 receivedServiceMessages[0],
                 capturedActivities[1],

--- a/AutomatedTesting/ConnectionTests/SingleService/SubscribeTests.cs
+++ b/AutomatedTesting/ConnectionTests/SingleService/SubscribeTests.cs
@@ -72,12 +72,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -152,11 +152,11 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -198,7 +198,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, channels.Count);
+            Assert.HasCount(2, channels);
             Assert.AreEqual(channelName, channels[0]);
             Assert.AreEqual(channelName, channels[1]);
             #endregion
@@ -233,7 +233,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(subscription1);
             Assert.IsNotNull(subscription2);
-            Assert.AreEqual(2, groups.Count);
+            Assert.HasCount(2, groups);
             Assert.AreEqual(groupName, groups[0]);
             Assert.AreNotEqual(groupName, groups[1]);
             #endregion
@@ -481,12 +481,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result1);
             Assert.IsNotNull(result2);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(2, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(2, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -554,12 +554,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(exception, exceptions[0]);
@@ -617,16 +617,15 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
-            Assert.IsInstanceOfType<InvalidDataException>(exceptions[0]);
-            Assert.AreEqual("MetaData is not valid", exceptions[0].Message);
+            Assert.IsInstanceOfType<InvalidCastException>(exceptions[0]);
             #endregion
 
             #region Verify
@@ -689,12 +688,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -775,12 +774,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -851,12 +850,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -927,15 +926,15 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(exceptions, 2, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(0, messages.Count);
-            Assert.AreEqual(1, errorActions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.IsEmpty(messages);
+            Assert.HasCount(1, errorActions);
             Assert.AreEqual(typeof(NamedAndVersionedMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(1, exceptions.OfType<InvalidCastException>().Count());
-            Assert.IsTrue(exceptions.Contains(exception));
+            Assert.Contains(exception, exceptions);
             #endregion
 
             #region Verify
@@ -1009,12 +1008,12 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, channels.Count);
-            Assert.AreEqual(1, groups.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
-            Assert.AreEqual(1, errorActions.Count);
-            Assert.AreEqual(1, exceptions.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, channels);
+            Assert.HasCount(1, groups);
+            Assert.HasCount(1, serviceMessages);
+            Assert.HasCount(1, errorActions);
+            Assert.HasCount(1, exceptions);
             Assert.AreEqual(typeof(BasicMessage).GetCustomAttribute<MessageChannelAttribute>(false)?.Name, channels[0]);
             Assert.IsNull(groups[0]);
             Assert.AreEqual(serviceMessages[0].ID, messages[0].ID);
@@ -1024,7 +1023,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             Assert.AreEqual(exception, exceptions[0]);
             Assert.IsTrue(acknowledged);
             Trace.WriteLine($"Time to process message {messages[0].ProcessedTimestamp.Subtract(messages[0].ReceivedTimestamp).TotalMilliseconds}ms");
-            Assert.AreEqual(2, capturedActivities.Count);
+            Assert.HasCount(2, capturedActivities);
             ConnectionHelper.ValidatePublishActivity<BasicMessage>(
                 publishedMessages[0],
                 capturedActivities[0],
@@ -1128,8 +1127,8 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             #region Assert
             Assert.IsNotNull(subscription);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, actions.Count);
-            Assert.AreEqual(1, serviceMessages.Count);
+            Assert.HasCount(1, actions);
+            Assert.HasCount(1, serviceMessages);
             if (Equals(headerValue, checkValue) && Equals(messageHeaderValue,messageHeaderCheckValue) && Equals(messageValue,messageCheckValue))
             {
                 Assert.IsTrue(await Helper.WaitForCount(messages, 1, TimeSpan.FromMinutes(1)));
@@ -1140,7 +1139,7 @@ namespace AutomatedTesting.ConnectionTests.SingleService
             }
             else
             {
-                Assert.AreEqual(0, messages.Count);
+                Assert.IsEmpty(messages);
             }
             Assert.AreEqual(acknowledgeDrop, acknowledged);
             #endregion

--- a/AutomatedTesting/ConnectionTests/SystemMetricTests.cs
+++ b/AutomatedTesting/ConnectionTests/SystemMetricTests.cs
@@ -33,28 +33,28 @@ namespace AutomatedTesting.ContractConnectionTests
 
         private static void CheckMeasurement(IReadOnlyList<CollectedMeasurement<long>> readOnlyList, int count, long value)
         {
-            Assert.AreEqual(count, readOnlyList.Count);
+            Assert.HasCount(count, readOnlyList);
             if (count>0)
                 Assert.AreEqual(value, readOnlyList[0].Value);
         }
 
         private static void CheckMeasurement(IReadOnlyList<CollectedMeasurement<double>> readOnlyList, int count, double value)
         {
-            Assert.AreEqual(count, readOnlyList.Count);
+            Assert.HasCount(count, readOnlyList);
             if (count>0)
                 Assert.AreEqual(value, readOnlyList[0].Value);
         }
 
         private static void CheckMeasurementGreaterThan(IReadOnlyList<CollectedMeasurement<long>> readOnlyList, int count, long value)
         {
-            Assert.AreEqual(count, readOnlyList.Count);
-            Assert.IsTrue(value<readOnlyList[0].Value);
+            Assert.HasCount(count, readOnlyList);
+            Assert.IsLessThan(readOnlyList[0].Value, value);
         }
 
         private static void CheckMeasurementGreaterThan(IReadOnlyList<CollectedMeasurement<double>> readOnlyList, int count, double value)
         {
-            Assert.AreEqual(count, readOnlyList.Count);
-            Assert.IsTrue(value<readOnlyList[0].Value);
+            Assert.HasCount(count, readOnlyList);
+            Assert.IsLessThan(readOnlyList[0].Value, value);
         }
 
         private static void AreMeasurementsEquals(IReadOnlyList<CollectedMeasurement<long>> left, IReadOnlyList<CollectedMeasurement<long>> right)

--- a/AutomatedTesting/Encoders/TestMessageEncoderWithInjection.cs
+++ b/AutomatedTesting/Encoders/TestMessageEncoderWithInjection.cs
@@ -11,7 +11,7 @@ namespace AutomatedTesting.Encoders
         public ValueTask<CustomEncoderWithInjectionMessage?> DecodeAsync(Stream stream)
         {
             var message = Encoding.ASCII.GetString(new BinaryReader(stream).ReadBytes((int)stream.Length));
-            Assert.IsTrue(message.StartsWith($"{injectableService.Name}:"));
+            Assert.StartsWith($"{injectableService.Name}:", message);
             return ValueTask.FromResult<CustomEncoderWithInjectionMessage?>(new CustomEncoderWithInjectionMessage(message.Substring($"{injectableService.Name}:".Length)));
         }
 

--- a/BenchMark/BenchMark.csproj
+++ b/BenchMark/BenchMark.csproj
@@ -12,6 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\Connectors\InMemory\InMemory.csproj" />
 	  <ProjectReference Include="..\Core\Core.csproj" />
 	</ItemGroup>
 

--- a/BenchMark/InMemoryBenchmarks/SubscribingInMemory.cs
+++ b/BenchMark/InMemoryBenchmarks/SubscribingInMemory.cs
@@ -1,0 +1,56 @@
+﻿using BenchMark.Messages;
+using BenchmarkDotNet.Attributes;
+using MQContract;
+using MQContract.Interfaces;
+
+namespace BenchMark.InMemoryBenchmarks
+{
+    public class SubscribingInMemory
+    {
+        private const string channel = "Accouncements";
+        private static readonly Announcement testMessage = new("The quick brown fox");
+
+        [Params(1, 10, 100, 1000, 5000, 10000, 50000, 100000, 250000)]
+        public int MessageCount { get; set; }
+        private IContractedConnection? contractConnection;
+        private TaskCompletionSource? completionSource;
+        private ISubscription? subscription;
+
+        [IterationSetup]
+        public void SetupIteration()
+        {
+            var count = MessageCount;
+            contractConnection = ContractConnection.Instance(new MQContract.InMemory.Connection());
+            completionSource = new();
+            var subTask = contractConnection.SubscribeAsync<Announcement>(
+                (message) =>
+                {
+                    count--;
+                    if (count<=0)
+                        completionSource.TrySetResult();
+                    return ValueTask.CompletedTask;
+                },
+                (err) => { },
+                channel:channel
+            ).AsTask();
+            subTask.Wait();
+            subscription = subTask.Result;
+        }
+
+        [IterationCleanup()]
+        public void CleanupIteration()
+        {
+            subscription?.EndAsync().AsTask().Wait();
+            contractConnection?.CloseAsync().AsTask().Wait();
+        }
+
+        [Benchmark]
+        public async Task ReadAllSubscriptionMessages()
+        {
+            var count = MessageCount;
+            for (var x = 0; x<count; x++)
+                await contractConnection!.PublishAsync<Announcement>(testMessage,channel: channel);
+            await completionSource!.Task;
+        }
+    }
+}

--- a/BenchMark/Program.cs
+++ b/BenchMark/Program.cs
@@ -1,6 +1,10 @@
 ﻿// See https://aka.ms/new-console-template for more information
-using BenchMark.PublishBenchmarks;
+using BenchMark.InMemoryBenchmarks;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
-_ = BenchmarkRunner.Run<Publishing>();
-_ = BenchmarkRunner.Run<PublishingWithMiddleware>();
+BenchmarkRunner.Run(
+    typeof(SubscribingInMemory).Assembly, // all benchmarks from given assembly are going to be executed
+    ManualConfig
+                .Create(DefaultConfig.Instance)
+                .WithOptions(ConfigOptions.DisableLogFile));

--- a/BenchMark/PublishBenchmarks/PublishingWithMiddleware.cs
+++ b/BenchMark/PublishBenchmarks/PublishingWithMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using MQContract;
 using MQContract.Interfaces;
-using MQContract.Interfaces.Service;
 
 namespace BenchMark.PublishBenchmarks
 {

--- a/Connectors/AzureServiceBus/Exceptions.cs
+++ b/Connectors/AzureServiceBus/Exceptions.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MQContract.AzureServiceBus
+﻿namespace MQContract.AzureServiceBus
 {
     /// <summary>
     /// Thrown when a bulk publish request exceeds the usable message batch size

--- a/Core/Connections/AConnection.cs
+++ b/Core/Connections/AConnection.cs
@@ -14,7 +14,6 @@ using MQContract.Subscriptions;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
-using System.Threading.Channels;
 
 namespace MQContract.Connections
 {

--- a/Core/Connections/DecodeServiceMessageResult.cs
+++ b/Core/Connections/DecodeServiceMessageResult.cs
@@ -1,9 +1,4 @@
 ﻿using MQContract.Messages;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MQContract.Connections
 {

--- a/Core/Factories/AConverter.cs
+++ b/Core/Factories/AConverter.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+using MQContract.Attributes;
+using MQContract.Interfaces.Conversion;
+using MQContract.Interfaces.Messages;
+using System.Reflection;
+
+namespace MQContract.Factories
+{
+    internal abstract class AConverter<T,M>
+        : IConversionPath<T>
+    {
+        private readonly string messageTypeName = $"{typeof(M).GetCustomAttribute<MessageNameAttribute>()?.Value??Utility.TypeName<M>()}-{typeof(M).GetCustomAttribute<MessageVersionAttribute>()?.Version.ToString()??"0.0.0.0"}";
+
+        protected abstract ValueTask<T?> ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream);
+
+        ValueTask<T?> IConversionPath<T>.ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream)
+            => ConvertMessageAsync(logger, message, dataStream);
+
+        bool IConversionPath<T>.IsMatch(string metaData)
+            => messageTypeName.Equals(metaData, StringComparison.InvariantCulture);
+    }
+}

--- a/Core/Factories/ConversionPath.cs
+++ b/Core/Factories/ConversionPath.cs
@@ -7,7 +7,7 @@ using MQContract.Interfaces.Messages;
 
 namespace MQContract.Factories
 {
-    internal class ConversionPath<T, V> : IConversionPath<V>
+    internal class ConversionPath<T, V> : AConverter<V,T>
         where T : class
         where V : class
     {
@@ -24,7 +24,7 @@ namespace MQContract.Factories
             messageEncoder = (IMessageTypeEncoder<T>)(serviceProvider!=null ? ActivatorUtilities.CreateInstance(serviceProvider, encoderType) : Activator.CreateInstance(encoderType)!);
         }
 
-        public async ValueTask<V?> ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream = null)
+        protected override async ValueTask<V?> ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream)
         {
             dataStream ??= new MemoryStream(message.Data.ToArray());
             object? result = await (globalMessageEncoder!=null && messageEncoder is JsonEncoder<T> ? globalMessageEncoder.DecodeAsync<T>(dataStream) : messageEncoder.DecodeAsync(dataStream));

--- a/Core/Factories/MessageTypeFactory.cs
+++ b/Core/Factories/MessageTypeFactory.cs
@@ -9,14 +9,12 @@ using MQContract.Interfaces.Messages;
 using MQContract.Messages;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text.RegularExpressions;
 
 namespace MQContract.Factories
 {
     internal class MessageTypeFactory<T>
-        : IMessageFactory<T>
+        : AConverter<T,T>, IMessageFactory<T>
     {
-        private static Regex RegMetaData => new(@"^(.+)-((\d+\.)*(\d+))$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
 
         private readonly IMessageEncoder? globalMessageEncoder;
         private readonly IMessageTypeEncoder<T>? messageEncoder;
@@ -81,7 +79,7 @@ namespace MQContract.Factories
                 var conv = paths[x];
                 var destType = ExtractGenericArguements(conv.First().GetType())[0];
                 paths.AddRange(
-                    types
+                    [.. types
                     .Where(t => Array.Exists(t.GetInterfaces(), iface => iface.IsGenericType &&
                         iface.GetGenericTypeDefinition() == typeof(IMessageConverter<,>)
                         && iface.GetGenericArguments()[1] == destType
@@ -90,8 +88,7 @@ namespace MQContract.Factories
                     .Select(t => conv.Prepend((serviceProvider == null ?
                         Activator.CreateInstance(t)! :
                         ActivatorUtilities.CreateInstance(serviceProvider, t)
-                    )))
-                    .ToArray()
+                    )))]
                 );
             }
 
@@ -111,21 +108,6 @@ namespace MQContract.Factories
 
         private static Type[] ExtractGenericArguements(Type t) => t.GetInterfaces().First(iface => iface.IsGenericType && iface.GetGenericTypeDefinition()==typeof(IMessageConverter<,>)).GetGenericArguments();
 
-        private static bool IsMessageTypeMatch(string metaData, Type t)
-        {
-            var match = RegMetaData.Match(metaData);
-            if (match.Success)
-            {
-                if (match.Groups[1].Value==t.GetCustomAttributes<MessageNameAttribute>().Select(mn => mn.Value).FirstOrDefault(Utility.TypeName(t))
-                    && new Version(match.Groups[2].Value)==new Version(t.GetCustomAttributes<MessageVersionAttribute>().Select(mc => mc.Version.ToString()).FirstOrDefault("0.0.0.0")))
-                    return true;
-
-            }
-            else
-                throw new InvalidDataException("MetaData is not valid");
-            return false;
-        }
-
         public async ValueTask<ServiceMessage> ConvertMessageAsync(T message, bool ignoreChannel, string? channel, MessageHeader messageHeader)
         {
             if (string.IsNullOrWhiteSpace(channel)&&!ignoreChannel)
@@ -140,7 +122,7 @@ namespace MQContract.Factories
             );
         }
 
-        async ValueTask<T?> IConversionPath<T>.ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream)
+        protected override async ValueTask<T?> ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream)
         {
             if (!IgnoreMessageHeader)
 #pragma warning disable S3236 // Caller information arguments should not be provided explicitly
@@ -150,11 +132,11 @@ namespace MQContract.Factories
                 throw ErrorServiceMessage.DecodeError(message.Data);
             IConversionPath<T>? converter = null;
             T? result;
-            if (IgnoreMessageHeader || IsMessageTypeMatch(message.MessageTypeID, typeof(T)))
+            if (IgnoreMessageHeader || ((IConversionPath<T>)this).IsMatch(message.MessageTypeID))
                 result = await (messageEncoder?.DecodeAsync(new MemoryStream(message.Data.ToArray()))??globalMessageEncoder!.DecodeAsync<T>(new MemoryStream(message.Data.ToArray())));
             else
             {
-                converter = converters.FirstOrDefault(conv => IsMessageTypeMatch(message.MessageTypeID, conv.GetType().GetGenericArguments()[0]));
+                converter = converters.FirstOrDefault(conv => conv.IsMatch(message.MessageTypeID));
                 if (converter==null)
                     throw new InvalidCastException();
                 result = await converter.ConvertMessageAsync(logger, message, dataStream: new MemoryStream(message.Data.ToArray()));

--- a/Core/Interfaces/Conversion/IConversionPath.cs
+++ b/Core/Interfaces/Conversion/IConversionPath.cs
@@ -5,6 +5,7 @@ namespace MQContract.Interfaces.Conversion
 {
     internal interface IConversionPath<T>
     {
+        bool IsMatch(string metaData);
         ValueTask<T?> ConvertMessageAsync(ILogger? logger, IEncodedMessage message, Stream? dataStream = null);
     }
 }

--- a/Shared.props
+++ b/Shared.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<VersionPrefix>2.10</VersionPrefix>
+		<VersionPrefix>2.11</VersionPrefix>
 		<PackageProjectUrl>https://github.com/roger-castaldo/MQContract</PackageProjectUrl>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/roger-castaldo/MQContract</RepositoryUrl>


### PR DESCRIPTION
improved performance by updating message type checks to favor using pre-constructed types instead of a static regular expression for performance gains.